### PR TITLE
Finish feedback gain unit conversions

### DIFF
--- a/src/main/native/cpp/Util.cpp
+++ b/src/main/native/cpp/Util.cpp
@@ -12,7 +12,7 @@
 
 void sysid::CreateTooltip(const char* text) {
   ImGui::SameLine();
-  ImGui::TextDisabled("  (?)");
+  ImGui::TextDisabled(" (?)");
 
   if (ImGui::IsItemHovered()) {
     ImGui::BeginTooltip();

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -162,11 +162,15 @@ AnalysisManager::Gains AnalysisManager::Calculate() {
   // Calculate the appropriate gains.
   std::tuple<double, double> fb;
   if (m_settings.type == FeedbackControllerLoopType::kPosition) {
-    fb = sysid::CalculatePositionFeedbackGains(m_settings.preset,
-                                               m_settings.lqr, gains);
+    fb = sysid::CalculatePositionFeedbackGains(
+        m_settings.preset, m_settings.lqr, gains,
+        m_settings.calcGains ? m_settings.gearing : 1,
+        m_settings.calcGains ? m_settings.epr : 1);
   } else {
-    fb = sysid::CalculateVelocityFeedbackGains(m_settings.preset,
-                                               m_settings.lqr, gains);
+    fb = sysid::CalculateVelocityFeedbackGains(
+        m_settings.preset, m_settings.lqr, gains,
+        m_settings.calcGains ? m_settings.gearing : 1,
+        m_settings.calcGains ? m_settings.epr : 1);
   }
 
   // Calculate track width if applicable.

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -164,13 +164,15 @@ AnalysisManager::Gains AnalysisManager::Calculate() {
   if (m_settings.type == FeedbackControllerLoopType::kPosition) {
     fb = sysid::CalculatePositionFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
-        m_settings.convertGainsToEncTicks ? m_settings.gearing * m_settings.epr
-                                          : 1);
+        m_settings.convertGainsToEncTicks
+            ? m_settings.gearing * m_settings.epr * m_factor
+            : 1);
   } else {
     fb = sysid::CalculateVelocityFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
-        m_settings.convertGainsToEncTicks ? m_settings.gearing * m_settings.epr
-                                          : 1);
+        m_settings.convertGainsToEncTicks
+            ? m_settings.gearing * m_settings.epr * m_factor
+            : 1);
   }
 
   // Calculate track width if applicable.

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -164,13 +164,13 @@ AnalysisManager::Gains AnalysisManager::Calculate() {
   if (m_settings.type == FeedbackControllerLoopType::kPosition) {
     fb = sysid::CalculatePositionFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
-        m_settings.calcGains ? m_settings.gearing : 1,
-        m_settings.calcGains ? m_settings.epr : 1);
+        m_settings.convertGainsToEncTicks ? m_settings.gearing * m_settings.epr
+                                          : 1);
   } else {
     fb = sysid::CalculateVelocityFeedbackGains(
         m_settings.preset, m_settings.lqr, gains,
-        m_settings.calcGains ? m_settings.gearing : 1,
-        m_settings.calcGains ? m_settings.epr : 1);
+        m_settings.convertGainsToEncTicks ? m_settings.gearing * m_settings.epr
+                                          : 1);
   }
 
   // Calculate track width if applicable.

--- a/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
+++ b/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
@@ -20,7 +20,7 @@ using Ka_t = decltype(1_V / 1_mps_sq);
 
 std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains) {
+    const FeedforwardGains& feedforwardGains, double gearing, int epr) {
   // Get Ks, Kv, and Ka from the tuple.
   auto& [Ks, Kv, Ka] = feedforwardGains;
   static_cast<void>(Ks);
@@ -40,9 +40,10 @@ std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
                                  preset.positionMeasurementDelay);
 
     return std::make_tuple(
-        controller.K(0, 0) * preset.outputConversionFactor,
+        controller.K(0, 0) * preset.outputConversionFactor / (gearing * epr),
         controller.K(0, 1) * preset.outputConversionFactor /
-            (preset.normalized ? 1 : preset.period.to<double>()));
+            (gearing * epr *
+             (preset.normalized ? 1 : preset.period.to<double>())));
   }
 
   // This is our special model to avoid instabilities in the LQR.
@@ -62,7 +63,7 @@ std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
 
 std::tuple<double, double> sysid::CalculateVelocityFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains) {
+    const FeedforwardGains& feedforwardGains, double gearing, int epr) {
   // Get Ks, Kv, and Ka from the tuple.
   auto& [Ks, Kv, Ka] = feedforwardGains;
   static_cast<void>(Ks);
@@ -85,6 +86,6 @@ std::tuple<double, double> sysid::CalculateVelocityFeedbackGains(
                                preset.velocityMeasurementDelay);
 
   return std::make_tuple(controller.K(0, 0) * preset.outputConversionFactor /
-                             preset.outputVelocityTimeFactor,
+                             (preset.outputVelocityTimeFactor * gearing * epr),
                          0);
 }

--- a/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
+++ b/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
@@ -84,5 +84,7 @@ std::tuple<double, double> sysid::CalculateVelocityFeedbackGains(
   controller.LatencyCompensate(system, preset.period,
                                preset.velocityMeasurementDelay);
 
-  return std::make_tuple(controller.K(0, 0) * preset.outputConversionFactor, 0);
+  return std::make_tuple(controller.K(0, 0) * preset.outputConversionFactor /
+                             preset.outputVelocityTimeFactor,
+                         0);
 }

--- a/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
+++ b/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
@@ -20,7 +20,7 @@ using Ka_t = decltype(1_V / 1_mps_sq);
 
 std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains, double gearing, int epr) {
+    const FeedforwardGains& feedforwardGains, double encFactor) {
   // Get Ks, Kv, and Ka from the tuple.
   auto& [Ks, Kv, Ka] = feedforwardGains;
   static_cast<void>(Ks);
@@ -40,10 +40,9 @@ std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
                                  preset.positionMeasurementDelay);
 
     return std::make_tuple(
-        controller.K(0, 0) * preset.outputConversionFactor / (gearing * epr),
+        controller.K(0, 0) * preset.outputConversionFactor / encFactor,
         controller.K(0, 1) * preset.outputConversionFactor /
-            (gearing * epr *
-             (preset.normalized ? 1 : preset.period.to<double>())));
+            (encFactor * (preset.normalized ? 1 : preset.period.to<double>())));
   }
 
   // This is our special model to avoid instabilities in the LQR.
@@ -58,12 +57,12 @@ std::tuple<double, double> sysid::CalculatePositionFeedbackGains(
                                preset.positionMeasurementDelay);
 
   return std::make_tuple(
-      Kv * controller.K(0, 0) * preset.outputConversionFactor, 0);
+      Kv * controller.K(0, 0) * preset.outputConversionFactor / encFactor, 0);
 }
 
 std::tuple<double, double> sysid::CalculateVelocityFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains, double gearing, int epr) {
+    const FeedforwardGains& feedforwardGains, double encFactor) {
   // Get Ks, Kv, and Ka from the tuple.
   auto& [Ks, Kv, Ka] = feedforwardGains;
   static_cast<void>(Ks);
@@ -86,6 +85,6 @@ std::tuple<double, double> sysid::CalculateVelocityFeedbackGains(
                                preset.velocityMeasurementDelay);
 
   return std::make_tuple(controller.K(0, 0) * preset.outputConversionFactor /
-                             (preset.outputVelocityTimeFactor * gearing * epr),
+                             (preset.outputVelocityTimeFactor * encFactor),
                          0);
 }

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -351,6 +351,13 @@ void Analyzer::Display() {
       if (ImGui::Combo("Gain Preset", &m_selectedPreset, kPresetNames,
                        IM_ARRAYSIZE(kPresetNames))) {
         m_settings.preset = m_presets[kPresetNames[m_selectedPreset]];
+        if (m_settings.preset != presets::kWPILibNew &&
+            m_settings.preset != presets::kWPILibOld &&
+            m_settings.preset != presets::kDefault) {
+          m_settings.calcGains = true;
+        } else {
+          m_settings.calcGains = false;
+        }
         Calculate();
       }
       ImGui::SameLine();
@@ -420,6 +427,34 @@ void Analyzer::Display() {
                       ImGui::GetFontSize() * 17);
 
       ImGui::SetCursorPosY(endY);
+
+      // Add EPR and Gearing for converting Feedback Gains
+      ImGui::Separator();
+      ImGui::Spacing();
+
+      if (ImGui::Checkbox("Convert Gains", &m_settings.calcGains)) {
+        Calculate();
+      }
+      sysid::CreateTooltip(
+          "Check this box if you are using a setup where the the gearing and "
+          "EPR affect the controller output.");
+
+      if (m_settings.calcGains) {
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10);
+        if (ImGui::InputDouble("Gearing", &m_settings.gearing, 0.0, 0.0,
+                               "%.1f") &&
+            m_settings.epr > 0) {
+          Calculate();
+        }
+        sysid::CreateTooltip(
+            "This is the gearing between your encoder and your shaft");
+
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10);
+        if (ImGui::InputInt("EPR", &m_settings.epr, 0) && m_settings.epr > 0) {
+          Calculate();
+        }
+        sysid::CreateTooltip("This is the edges per rotation for your encoder");
+      }
 
       ImGui::Separator();
       ImGui::Spacing();

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -351,12 +351,10 @@ void Analyzer::Display() {
       if (ImGui::Combo("Gain Preset", &m_selectedPreset, kPresetNames,
                        IM_ARRAYSIZE(kPresetNames))) {
         m_settings.preset = m_presets[kPresetNames[m_selectedPreset]];
-        if (m_settings.preset != presets::kWPILibNew &&
-            m_settings.preset != presets::kWPILibOld &&
-            m_settings.preset != presets::kDefault) {
-          m_settings.calcGains = true;
+        if (m_selectedPreset > 2) {
+          m_settings.convertGainsToEncTicks = true;
         } else {
-          m_settings.calcGains = false;
+          m_settings.convertGainsToEncTicks = false;
         }
         Calculate();
       }
@@ -432,28 +430,41 @@ void Analyzer::Display() {
       ImGui::Separator();
       ImGui::Spacing();
 
-      if (ImGui::Checkbox("Convert Gains", &m_settings.calcGains)) {
+      if (ImGui::Checkbox("Convert Gains to Encoder Ticks",
+                          &m_settings.convertGainsToEncTicks)) {
         Calculate();
       }
       sysid::CreateTooltip(
-          "Check this box if you are using a setup where the the gearing and "
-          "EPR affect the controller output.");
+          "Whether the feedback gains should be in terms of encoder ticks or "
+          "output units. Because smart motor controllers usually don't have "
+          "direct access to the output units (i.e. m/s for a drivetrain), they "
+          "perform feedback on the encoder units directly. If you are using a "
+          "PID Controller on the RoboRIO, you are probably performing feedback "
+          "on the output units directly.");
 
-      if (m_settings.calcGains) {
-        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10);
+      if (m_settings.convertGainsToEncTicks) {
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 5);
         if (ImGui::InputDouble("Gearing", &m_settings.gearing, 0.0, 0.0,
                                "%.1f") &&
             m_settings.epr > 0) {
           Calculate();
         }
         sysid::CreateTooltip(
-            "This is the gearing between your encoder and your shaft");
+            "The gearing between the encoder and the output shaft (# of "
+            "encoder turns / # of output shaft turns).");
 
-        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10);
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 5);
         if (ImGui::InputInt("EPR", &m_settings.epr, 0) && m_settings.epr > 0) {
           Calculate();
         }
-        sysid::CreateTooltip("This is the edges per rotation for your encoder");
+        sysid::CreateTooltip(
+            "The edges per rotation of your encoder. This is the number of "
+            "ticks reported in user code when the encoder is rotated exactly "
+            "once. Some common values for various motors/encoders "
+            "are:\n\nFalcon "
+            "500: 2048\nNEO: 1\nCTRE Mag Encoder / CANCoder: 4096\nREV Through "
+            "Bore "
+            "Encoder: 8192\n");
       }
 
       ImGui::Separator();

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -351,11 +351,7 @@ void Analyzer::Display() {
       if (ImGui::Combo("Gain Preset", &m_selectedPreset, kPresetNames,
                        IM_ARRAYSIZE(kPresetNames))) {
         m_settings.preset = m_presets[kPresetNames[m_selectedPreset]];
-        if (m_selectedPreset > 2) {
-          m_settings.convertGainsToEncTicks = true;
-        } else {
-          m_settings.convertGainsToEncTicks = false;
-        }
+        m_settings.convertGainsToEncTicks = m_selectedPreset > 2;
         Calculate();
       }
       ImGui::SameLine();
@@ -446,7 +442,7 @@ void Analyzer::Display() {
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 5);
         if (ImGui::InputDouble("Gearing", &m_settings.gearing, 0.0, 0.0,
                                "%.1f") &&
-            m_settings.epr > 0) {
+            m_settings.gearing > 0) {
           Calculate();
         }
         sysid::CreateTooltip(

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -66,6 +66,12 @@ class AnalysisManager {
 
     /** The dataset that is being analyzed. */
     int dataset = 0;
+
+    /** The Conversion factors. These contain values to convert feedback gains
+     * by gearing and epr. */
+    int epr = 1;
+    double gearing = 1;
+    bool calcGains = false;
   };
 
   /** Stores feedforward and feedback gains */

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -67,11 +67,11 @@ class AnalysisManager {
     /** The dataset that is being analyzed. */
     int dataset = 0;
 
-    /** The Conversion factors. These contain values to convert feedback gains
+    /** The conversion factors. These contain values to convert feedback gains
      * by gearing and epr. */
-    int epr = 1;
+    int epr = 1440;
     double gearing = 1;
-    bool calcGains = false;
+    bool convertGainsToEncTicks = false;
   };
 
   /** Stores feedforward and feedback gains */

--- a/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
+++ b/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
@@ -37,7 +37,7 @@ struct LQRParameters {
  */
 std::tuple<double, double> CalculatePositionFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains);
+    const FeedforwardGains& feedforwardGains, double gearing, int epr);
 
 /**
  * Calculates velocity feedback gains for the given controller preset, LQR
@@ -50,5 +50,5 @@ std::tuple<double, double> CalculatePositionFeedbackGains(
  */
 std::tuple<double, double> CalculateVelocityFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains);
+    const FeedforwardGains& feedforwardGains, double gearing, int epr);
 }  // namespace sysid

--- a/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
+++ b/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
@@ -34,10 +34,12 @@ struct LQRParameters {
  * @param params           The parameters for calculating optimal feedback
  *                         gains.
  * @param feedforwardGains The feedforward gains for the system.
+ * @param encFactor        The factor to convert the gains from output units to
+ *                         encoder units.
  */
 std::tuple<double, double> CalculatePositionFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains, double gearing, int epr);
+    const FeedforwardGains& feedforwardGains, double encFactor = 1.0);
 
 /**
  * Calculates velocity feedback gains for the given controller preset, LQR
@@ -47,8 +49,10 @@ std::tuple<double, double> CalculatePositionFeedbackGains(
  * @param params           The parameters for calculating optimal feedback
  *                         gains.
  * @param feedforwardGains The feedforward gains for the system.
+ * @param encFactor        The factor to convert the gains from output units to
+ *                         encoder units.
  */
 std::tuple<double, double> CalculateVelocityFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
-    const FeedforwardGains& feedforwardGains, double gearing, int epr);
+    const FeedforwardGains& feedforwardGains, double encFactor = 1.0);
 }  // namespace sysid

--- a/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
+++ b/src/main/native/include/sysid/analysis/FeedbackAnalysis.h
@@ -35,7 +35,8 @@ struct LQRParameters {
  *                         gains.
  * @param feedforwardGains The feedforward gains for the system.
  * @param encFactor        The factor to convert the gains from output units to
- *                         encoder units.
+ *                         encoder units. This is usually encoder EPR * gearing
+ *                         * units per rotation.
  */
 std::tuple<double, double> CalculatePositionFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,
@@ -50,7 +51,8 @@ std::tuple<double, double> CalculatePositionFeedbackGains(
  *                         gains.
  * @param feedforwardGains The feedforward gains for the system.
  * @param encFactor        The factor to convert the gains from output units to
- *                         encoder units.
+ *                         encoder units. This is usually encoder EPR * gearing
+ *                         * units per rotation.
  */
 std::tuple<double, double> CalculateVelocityFeedbackGains(
     const FeedbackControllerPreset& preset, const LQRParameters& params,

--- a/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
+++ b/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
@@ -37,6 +37,7 @@ struct FeedbackControllerPreset {
   /** Checks equality between two feedback controller presets. */
   constexpr bool operator==(const FeedbackControllerPreset& rhs) const {
     return outputConversionFactor == rhs.outputConversionFactor &&
+           outputVelocityTimeFactor == rhs.outputVelocityTimeFactor &&
            period == rhs.period && normalized == rhs.normalized &&
            positionMeasurementDelay == rhs.positionMeasurementDelay &&
            velocityMeasurementDelay == rhs.velocityMeasurementDelay;

--- a/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
+++ b/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
@@ -17,6 +17,11 @@ struct FeedbackControllerPreset {
   /** The conversion factor between volts and the final controller output. */
   double outputConversionFactor;
 
+  /** The conversion factor for using controller output for velocity gains. This
+   * is necessary as some controllers do velocity controls with different time
+   * units.*/
+  double outputVelocityTimeFactor;
+
   /** The period at which the controller runs. */
   units::second_t period;
 
@@ -47,28 +52,28 @@ struct FeedbackControllerPreset {
 enum class FeedbackControllerLoopType { kPosition, kVelocity };
 
 namespace presets {
-constexpr FeedbackControllerPreset kDefault{1.0, 20_ms, true, 0_s, 0_s};
+constexpr FeedbackControllerPreset kDefault{1.0, 1.0, 20_ms, true, 0_s, 0_s};
 
 constexpr FeedbackControllerPreset kWPILibNew{kDefault};
-constexpr FeedbackControllerPreset kWPILibOld{1.0 / 12.0, 50_ms, false, 0_s,
-                                              0_s};
+constexpr FeedbackControllerPreset kWPILibOld{1.0 / 12.0, 1.0, 50_ms,
+                                              false,      0_s, 0_s};
 
 // https://phoenix-documentation.readthedocs.io/en/latest/ch14_MCSensor.html#changing-velocity-measurement-parameters
 // 100 ms sampling period + a moving average window size of 64 (i.e. a 64-tap
 // FIR) = 100 / 2 ms + (64 - 1) / 2 ms = 81.5 ms.
-constexpr FeedbackControllerPreset kCTRENew{1.0 / 12.0, 1_ms, true, 0_s,
-                                            81.5_ms};
-constexpr FeedbackControllerPreset kCTREOld{1023.0 / 12.0, 1_ms, false, 0_s,
-                                            81.5_ms};
+constexpr FeedbackControllerPreset kCTRENew{1.0 / 12.0, 0.1, 1_ms,
+                                            true,       0_s, 81.5_ms};
+constexpr FeedbackControllerPreset kCTREOld{1023.0 / 12.0, 0.1, 1_ms,
+                                            false,         0_s, 81.5_ms};
 
 // According to a Rev employee on the FRC Discord the window size is 40 so delay
 // = (40-1)/2 ms = 19.5 ms.
-constexpr FeedbackControllerPreset kREVBrushless{1.0 / 12.0, 1_ms, false, 0_s,
-                                                 19.5_ms};
+constexpr FeedbackControllerPreset kREVBrushless{1.0 / 12.0, 60.0, 1_ms,
+                                                 false,      0_s,  19.5_ms};
 
 // https://www.revrobotics.com/content/sw/max/sw-docs/cpp/classrev_1_1_c_a_n_encoder.html#a7e6ce792bc0c0558fb944771df572e6a
 // 64-tap FIR = (64 - 1) / 2 ms = 31.5 ms delay.
-constexpr FeedbackControllerPreset kREVBrushed{1.0 / 12.0, 1_ms, false, 0_s,
-                                               31.5_ms};
+constexpr FeedbackControllerPreset kREVBrushed{1.0 / 12.0, 60.0, 1_ms,
+                                               false,      0_s,  31.5_ms};
 }  // namespace presets
 }  // namespace sysid

--- a/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
@@ -19,7 +19,7 @@ TEST(FeedbackAnalysis, Velocity1) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kDefault, params, {Ks, Kv, Ka});
+      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 1, 1);
 
   EXPECT_NEAR(Kp, 2.11, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -33,9 +33,23 @@ TEST(FeedbackAnalysis, Velocity2) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kDefault, params, {Ks, Kv, Ka});
+      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 1, 1);
 
   EXPECT_NEAR(Kp, 3.11, 0.05);
+  EXPECT_NEAR(Kd, 0.00, 0.05);
+}
+
+TEST(FeedbackAnalysis, VelocityConversion) {
+  auto Ks = 0.547;
+  auto Kv = 0.0693;
+  auto Ka = 0.1170;
+
+  sysid::LQRParameters params{1, 1.5, 7};
+
+  auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
+      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 3.0, 1023);
+
+  EXPECT_NEAR(Kp, 0.001, 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }
 
@@ -47,9 +61,23 @@ TEST(FeedbackAnalysis, VelocityCTRE) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kCTRENew, params, {Ks, Kv, Ka});
+      sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 1, 1);
 
   EXPECT_NEAR(Kp, 0.25, 0.05);
+  EXPECT_NEAR(Kd, 0.00, 0.05);
+}
+
+TEST(FeedbackAnalysis, VelocityCTREConversion) {
+  auto Ks = 0.024;
+  auto Kv = 1.97;
+  auto Ka = 0.179;
+
+  sysid::LQRParameters params{1, 1.5, 7};
+
+  auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
+      sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 3.0, 1);
+
+  EXPECT_NEAR(Kp, 0.08, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }
 
@@ -61,7 +89,7 @@ TEST(FeedbackAnalysis, VelocityREV) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka});
+      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka}, 1, 1);
 
   EXPECT_NEAR(Kp, 0.00241, 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);

--- a/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
@@ -38,3 +38,31 @@ TEST(FeedbackAnalysis, Velocity2) {
   EXPECT_NEAR(Kp, 3.11, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }
+
+TEST(FeedbackAnalysis, VelocityCTRE) {
+  auto Ks = 0.024;
+  auto Kv = 1.97;
+  auto Ka = 0.179;
+
+  sysid::LQRParameters params{1, 1.5, 7};
+
+  auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
+      sysid::presets::kCTRENew, params, {Ks, Kv, Ka});
+
+  EXPECT_NEAR(Kp, 0.25, 0.05);
+  EXPECT_NEAR(Kd, 0.00, 0.05);
+}
+
+TEST(FeedbackAnalysis, VelocityREV) {
+  auto Ks = 0.024;
+  auto Kv = 1.97;
+  auto Ka = 0.179;
+
+  sysid::LQRParameters params{1, 1.5, 7};
+
+  auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
+      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka});
+
+  EXPECT_NEAR(Kp, 0.00241, 0.005);
+  EXPECT_NEAR(Kd, 0.00, 0.05);
+}

--- a/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
@@ -19,7 +19,7 @@ TEST(FeedbackAnalysis, Velocity1) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 1, 1);
+      sysid::presets::kDefault, params, {Ks, Kv, Ka});
 
   EXPECT_NEAR(Kp, 2.11, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -33,7 +33,7 @@ TEST(FeedbackAnalysis, Velocity2) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 1, 1);
+      sysid::presets::kDefault, params, {Ks, Kv, Ka});
 
   EXPECT_NEAR(Kp, 3.11, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -47,7 +47,7 @@ TEST(FeedbackAnalysis, VelocityConversion) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 3.0, 1023);
+      sysid::presets::kDefault, params, {Ks, Kv, Ka}, 3.0 * 1023);
 
   EXPECT_NEAR(Kp, 0.001, 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -61,7 +61,7 @@ TEST(FeedbackAnalysis, VelocityCTRE) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 1, 1);
+      sysid::presets::kCTRENew, params, {Ks, Kv, Ka});
 
   EXPECT_NEAR(Kp, 0.25, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -75,7 +75,7 @@ TEST(FeedbackAnalysis, VelocityCTREConversion) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 3.0, 1);
+      sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 3.0);
 
   EXPECT_NEAR(Kp, 0.08, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
@@ -89,7 +89,7 @@ TEST(FeedbackAnalysis, VelocityREV) {
   sysid::LQRParameters params{1, 1.5, 7};
 
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
-      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka}, 1, 1);
+      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka});
 
   EXPECT_NEAR(Kp, 0.00241, 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);

--- a/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedbackAnalysisTest.cpp
@@ -49,7 +49,9 @@ TEST(FeedbackAnalysis, VelocityConversion) {
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
       sysid::presets::kDefault, params, {Ks, Kv, Ka}, 3.0 * 1023);
 
-  EXPECT_NEAR(Kp, 0.001, 0.005);
+  // This should have the same Kp as the test above, but scaled by a factor of 3
+  // * 1023.
+  EXPECT_NEAR(Kp, 3.11 / (3 * 1023), 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }
 
@@ -77,7 +79,9 @@ TEST(FeedbackAnalysis, VelocityCTREConversion) {
   auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
       sysid::presets::kCTRENew, params, {Ks, Kv, Ka}, 3.0);
 
-  EXPECT_NEAR(Kp, 0.08, 0.05);
+  // This should have the same Kp as the test above, but scaled by a factor
+  // of 3.
+  EXPECT_NEAR(Kp, 0.25 / 3, 0.05);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }
 
@@ -92,5 +96,21 @@ TEST(FeedbackAnalysis, VelocityREV) {
       sysid::presets::kREVBrushless, params, {Ks, Kv, Ka});
 
   EXPECT_NEAR(Kp, 0.00241, 0.005);
+  EXPECT_NEAR(Kd, 0.00, 0.05);
+}
+
+TEST(FeedbackAnalysis, VelocityREVConversion) {
+  auto Ks = 0.024;
+  auto Kv = 1.97;
+  auto Ka = 0.179;
+
+  sysid::LQRParameters params{1, 1.5, 7};
+
+  auto [Kp, Kd] = sysid::CalculateVelocityFeedbackGains(
+      sysid::presets::kREVBrushless, params, {Ks, Kv, Ka}, 3.0);
+
+  // This should have the same Kp as the test above, but scaled by a factor
+  // of 3.
+  EXPECT_NEAR(Kp, 0.00241 / 3, 0.005);
   EXPECT_NEAR(Kd, 0.00, 0.05);
 }


### PR DESCRIPTION
Fixes #8 

Divides by time conversion for native controller outputs. (e.g. SparkMax controller uses RPM -> divide by 60 to convert gains for that controller).
