### PR TITLE
Allow units override in Analyzer

### DIFF
--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -206,6 +206,19 @@ AnalysisManager::Gains AnalysisManager::Calculate() {
   return {ff, fb};
 }
 
+void AnalysisManager::OverrideUnits(const std::string& unit,
+                                    double unitsPerRotation) {
+  m_unit = unit;
+  m_factor = unitsPerRotation;
+  PrepareData();
+}
+
+void AnalysisManager::ResetUnitsFromJSON() {
+  m_unit = m_json.at("units").get<std::string>();
+  m_factor = m_json.at("unitsPerRotation").get<double>();
+  PrepareData();
+}
+
 void AnalysisManager::TrimQuasistaticData(std::vector<RawData>* data,
                                           double threshold, bool drivetrain) {
   data->erase(

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -118,6 +118,20 @@ class AnalysisManager {
   Gains Calculate();
 
   /**
+   * Overrides the units in the JSON with the user-provided ones.
+   *
+   * @param unit             The unit to output gains in.
+   * @param unitsPerRotation The conversion factor between rotations and the
+   *                         selected unit.
+   */
+  void OverrideUnits(const std::string& unit, double unitsPerRotation);
+
+  /**
+   * Resets the units back to those defined in the JSON.
+   */
+  void ResetUnitsFromJSON();
+
+  /**
    * Returns the analysis type of the current instance (read from the JSON).
    *
    * @return The analysis type.

--- a/src/main/native/include/sysid/view/Analyzer.h
+++ b/src/main/native/include/sysid/view/Analyzer.h
@@ -30,6 +30,9 @@ class Analyzer : public glass::View {
 
   static constexpr const char* kLoopTypes[] = {"Position", "Velocity"};
 
+  static constexpr const char* kUnits[] = {"Meters",  "Feet",      "Inches",
+                                           "Radians", "Rotations", "Degrees"};
+
   Analyzer();
 
   void Display() override;
@@ -69,6 +72,7 @@ class Analyzer : public glass::View {
   // Units
   double m_factor;
   std::string m_unit;
+  int m_selectedOverrideUnit = 0;
 
   // Data analysis
   std::unique_ptr<AnalysisManager> m_manager;


### PR DESCRIPTION
This lets users change the units and units per rotation when analyzing
their data in case they messed up entering these values in the Logger.