### PR TITLE
Fix bugs in AnalysisManager::TrimStepVoltageData

### DIFF
--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -120,7 +120,7 @@ void TrimStepVoltageData(std::vector<PreparedData>* data) {
 
   for (size_t i = 0; i < data->size(); ++i) {
     // Get the current acceleration.
-    double acc = data->at(i).acceleration;
+    double acc = std::abs(data->at(i).acceleration);
 
     // If we are not in caution, the acceleration values are still increasing.
     if (!caution) {
@@ -146,6 +146,8 @@ void TrimStepVoltageData(std::vector<PreparedData>* data) {
       break;
     }
   }
+
+  data->erase(data->begin(), data->begin() + idx);
 }
 
 /**


### PR DESCRIPTION
Step Trimming in Analysis manager currently doesn't trim the data.