### PR TITLE
Add median filtering and time trim

### DIFF
--- a/src/integrationtest/native/cpp/SimulationTest.cpp
+++ b/src/integrationtest/native/cpp/SimulationTest.cpp
@@ -103,6 +103,7 @@ class IntegrationTest : public ::testing::Test {
     auto path = m_manager->SaveJSON(PROJECT_ROOT_DIR);
     try {
       auto analyzerSettings = sysid::AnalysisManager::Settings{};
+      analyzerSettings.windowSize = 15;
       if (m_settings.mechanism == sysid::analysis::kArm) {
         analyzerSettings.motionThreshold = 0.01;  // Reduce threshold for arm
                                                   // test
@@ -117,11 +118,8 @@ class IntegrationTest : public ::testing::Test {
       wpi::outs() << "Ks: " << ff[0] << "\n"
                   << "Kv: " << ff[1] << "\nKa: " << ff[2] << "\n";
       wpi::outs().flush();
-      EXPECT_NEAR(Kv, ff[1], 0.30);
-
-      // Due to scheduling jitter in integration test, Ka is extremely
-      // inaccurate
-      EXPECT_NEAR(Ka, ff[2], 0.60);
+      EXPECT_NEAR(Kv, ff[1], 0.05);
+      EXPECT_NEAR(Ka, ff[2], 0.20);
 
       if (m_settings.mechanism == sysid::analysis::kElevator) {
         wpi::outs() << "KG: " << ff[3] << "\n";

--- a/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "sysid/analysis/FilteringUtils.h"
+
+#include <frc/LinearFilter.h>
+
+using namespace sysid;
+
+void sysid::TrimStepVoltageData(std::vector<PreparedData>* data,
+                                AnalysisManager::Settings& settings,
+                                units::second_t& minStepTime,
+                                units::second_t maxStepTime) {
+  auto firstTimestamp = data->at(0).timestamp;
+
+  // Trim data before max acceleration
+  data->erase(data->begin(),
+              std::max_element(
+                  data->begin(), data->end(), [](const auto& a, const auto& b) {
+                    return std::abs(a.acceleration) < std::abs(b.acceleration);
+                  }));
+
+  minStepTime = std::min(data->at(0).timestamp - firstTimestamp, minStepTime);
+
+  // If step duration hasn't been set yet, set calculate a default (find the
+  // entry before the acceleration first hits zero)
+  if (settings.stepTestDuration <= minStepTime) {
+    // Get noise floor
+    const double accelNoiseFloor =
+        GetAccelNoiseFloor(*data, settings.windowSize);
+    // Find latest element with nonzero acceleration
+    auto endIt = std::find_if(
+        std::reverse_iterator{data->end()},
+        std::reverse_iterator{data->begin()}, [&](const PreparedData& entry) {
+          return std::abs(entry.acceleration) > accelNoiseFloor;
+        });
+
+    // Calculate default duration
+    settings.stepTestDuration =
+        std::min(endIt->timestamp - data->front().timestamp + minStepTime + 1_s,
+                 maxStepTime);
+  }
+
+  // Find first entry greater than the step test duration
+  auto maxIt =
+      std::find_if(data->begin(), data->end(), [&](PreparedData entry) {
+        return entry.timestamp - data->front().timestamp + minStepTime >
+               settings.stepTestDuration;
+      });
+
+  // Trim data beyond desired step test duration
+  if (maxIt != data->end()) {
+    data->erase(maxIt, data->end());
+  }
+}
+
+double sysid::GetAccelNoiseFloor(const std::vector<PreparedData>& data,
+                                 int window) {
+  double sum = 0.0;
+  size_t step = window / 2;
+  frc::LinearFilter<double> averageFilter =
+      frc::LinearFilter<double>::MovingAverage(window);
+  for (size_t i = 0; i < data.size(); i++) {
+    double mean = averageFilter.Calculate(data[i].acceleration);
+    if (i >= step) {
+      sum += std::pow(data[i - step].acceleration - mean, 2);
+    }
+  }
+  return std::sqrt(sum / (data.size() - step));
+}

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -69,28 +69,34 @@ static std::vector<std::vector<ImPlotPoint>> PopulateTimeDomainSim(
 AnalyzerPlot::AnalyzerPlot(wpi::Logger& logger) : m_logger(logger) {
   // Pre-allocate our vectors with the max data size.
   for (auto&& title : kChartTitles) {
-    m_data[title].reserve(kMaxSize);
+    m_filteredData[title].reserve(kMaxSize);
   }
 }
 
-void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
+void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
+                           const std::vector<double>& ff,
                            const std::array<units::second_t, 4>& startTimes,
                            AnalysisType type, std::atomic<bool>& abort) {
   std::scoped_lock lock(m_mutex);
-  auto& [slow, fast] = data;
+  auto& [slow, fast] = filteredData;
+  auto& [rawSlow, rawFast] = rawData;
 
   // Clear all data vectors.
-  for (auto it = m_data.begin(); it != m_data.end(); ++it) {
-    if (abort) {
-      return;
-    }
+  for (auto it = m_filteredData.begin(); it != m_filteredData.end(); ++it) {
+    it->second.clear();
+  }
+
+  for (auto it = m_rawData.begin(); it != m_rawData.end(); ++it) {
     it->second.clear();
   }
 
   // Calculate step sizes to ensure that we only use the memory that we
   // allocated.
-  auto sStep = std::ceil(slow.size() * 1.0 / kMaxSize);
-  auto fStep = std::ceil(fast.size() * 1.0 / kMaxSize);
+  auto sStep = std::ceil(slow.size() * 1.0 / kMaxSize * 4);
+  auto fStep = std::ceil(fast.size() * 1.0 / kMaxSize * 4);
+
+  auto rawSStep = std::ceil(rawSlow.size() * 1.0 / kMaxSize * 4);
+  auto rawFStep = std::ceil(rawFast.size() * 1.0 / kMaxSize * 4);
 
   // Calculate min and max velocities and accelerations of the slow and fast
   // datasets respectively.
@@ -137,11 +143,11 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
     m_KvFit[0] = ImPlotPoint(ff[1] * sMinE, sMinE);
     m_KvFit[1] = ImPlotPoint(ff[1] * sMaxE, sMaxE);
 
-    m_data[kChartTitles[0]].emplace_back(Vportion, slow[i].velocity);
-    m_data[kChartTitles[2]].emplace_back((slow[i].timestamp - t).to<double>(),
-                                         slow[i].velocity);
-    m_data[kChartTitles[3]].emplace_back((slow[i].timestamp - t).to<double>(),
-                                         slow[i].acceleration);
+    m_filteredData[kChartTitles[0]].emplace_back(Vportion, slow[i].velocity);
+    m_filteredData[kChartTitles[2]].emplace_back(
+        (slow[i].timestamp - t).to<double>(), slow[i].velocity);
+    m_filteredData[kChartTitles[3]].emplace_back(
+        (slow[i].timestamp - t).to<double>(), slow[i].acceleration);
 
     if (i > 0) {
       // If the current timestamp is not in the startTimes array, it is the
@@ -152,7 +158,7 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
       if (std::find(startTimes.begin(), startTimes.end(), slow[i].timestamp) ==
           startTimes.end()) {
         auto dt = slow[i].timestamp - slow[i - 1].timestamp;
-        m_data[kChartTitles[6]].emplace_back(
+        m_filteredData[kChartTitles[6]].emplace_back(
             (slow[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
         dtSum += dt;
@@ -182,11 +188,12 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
     m_KaFit[0] = ImPlotPoint(ff[2] * fMinE, fMinE);
     m_KaFit[1] = ImPlotPoint(ff[2] * fMaxE, fMaxE);
 
-    m_data[kChartTitles[1]].emplace_back(Vportion, fast[i].acceleration);
-    m_data[kChartTitles[4]].emplace_back((fast[i].timestamp - t).to<double>(),
-                                         fast[i].velocity);
-    m_data[kChartTitles[5]].emplace_back((fast[i].timestamp - t).to<double>(),
-                                         fast[i].acceleration);
+    m_filteredData[kChartTitles[1]].emplace_back(Vportion,
+                                                 fast[i].acceleration);
+    m_filteredData[kChartTitles[4]].emplace_back(
+        (fast[i].timestamp - t).to<double>(), fast[i].velocity);
+    m_filteredData[kChartTitles[5]].emplace_back(
+        (fast[i].timestamp - t).to<double>(), fast[i].acceleration);
     if (i > 0) {
       // If the current timestamp is not in the startTimes array, it is the
       // during a test and should be included. If it is in the startTimes array,
@@ -196,7 +203,7 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
       auto dt = fast[i].timestamp - fast[i - 1].timestamp;
       if (dt > 0_s && std::find(startTimes.begin(), startTimes.end(),
                                 fast[i].timestamp) == startTimes.end()) {
-        m_data[kChartTitles[6]].emplace_back(
+        m_filteredData[kChartTitles[6]].emplace_back(
             (fast[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
         dtSum += dt;
@@ -218,7 +225,25 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
   m_dtMeanLine.emplace_back(maxTime.to<double>(),
                             units::millisecond_t{dtMean}.to<double>());
 
-  // Populate simulated time-domain data.
+  t = rawSlow[0].timestamp;
+  // Populate Raw Slow Time Series Data
+  for (size_t i = 0; i < rawSlow.size(); i += rawSStep) {
+    m_rawData[kChartTitles[2]].emplace_back(
+        (rawSlow[i].timestamp - t).to<double>(), rawSlow[i].velocity);
+    m_rawData[kChartTitles[3]].emplace_back(
+        (rawSlow[i].timestamp - t).to<double>(), rawSlow[i].acceleration);
+  }
+
+  t = rawFast[0].timestamp;
+  // Populate Raw fast Time Series Data
+  for (size_t i = 0; i < rawFast.size(); i += rawFStep) {
+    m_rawData[kChartTitles[4]].emplace_back(
+        (rawFast[i].timestamp - t).to<double>(), rawFast[i].velocity);
+    m_rawData[kChartTitles[5]].emplace_back(
+        (rawFast[i].timestamp - t).to<double>(), rawFast[i].acceleration);
+  }
+
+  // Populate Simulated Time Series Data.
   if (type == analysis::kElevator) {
     m_quasistaticSim =
         PopulateTimeDomainSim(slow, startTimes, fStep,
@@ -268,10 +293,10 @@ bool AnalyzerPlot::DisplayVoltageDomainPlots(ImVec2 plotSize) {
                         ImPlotAxisFlags_NoGridLines,
                         ImPlotAxisFlags_NoGridLines)) {
     // Get a reference to the data that we are plotting.
-    auto& data = m_data[kChartTitles[0]];
+    auto& data = m_filteredData[kChartTitles[0]];
 
     ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
-    ImPlot::PlotScatterG("Collected Data", Getter, data.data(), data.size());
+    ImPlot::PlotScatterG("Filtered Data", Getter, data.data(), data.size());
 
     ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 1.5);
     ImPlot::PlotLineG("Fit", Getter, m_KvFit, 2);
@@ -295,10 +320,10 @@ bool AnalyzerPlot::DisplayVoltageDomainPlots(ImVec2 plotSize) {
                         "Dynamic Acceleration", plotSize, ImPlotFlags_None,
                         ImPlotAxisFlags_NoGridLines)) {
     // Get a reference to the data we are plotting.
-    auto& data = m_data[kChartTitles[1]];
+    auto& data = m_filteredData[kChartTitles[1]];
 
     ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
-    ImPlot::PlotScatterG("Collected Data", Getter, data.data(), data.size());
+    ImPlot::PlotScatterG("Filtered Data", Getter, data.data(), data.size());
 
     ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 1.5);
     ImPlot::PlotLineG("Fit", Getter, m_KaFit, 2);
@@ -319,6 +344,16 @@ static void PlotSimData(std::vector<std::vector<ImPlotPoint>>& data) {
   }
 }
 
+static void PlotRawAndFiltered(std::vector<ImPlotPoint>& rawData,
+                               std::vector<ImPlotPoint>& filteredData) {
+  ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
+  ImPlot::PlotScatterG("Raw Data", Getter, rawData.data(), rawData.size());
+  // Plot Filtered Data after Raw data
+  ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
+  ImPlot::PlotScatterG("Filtered Data", Getter, filteredData.data(),
+                       filteredData.size());
+}
+
 bool AnalyzerPlot::DisplayTimeDomainPlots(ImVec2 plotSize) {
   std::unique_lock lock(m_mutex, std::defer_lock);
 
@@ -337,6 +372,11 @@ bool AnalyzerPlot::DisplayTimeDomainPlots(ImVec2 plotSize) {
         i % 2 == 0 ? "Velocity (units / s)" : "Acceleration (units / s / s)";
     bool isVelocity = (i == 2 || i == 4);
 
+    // Get a reference to the data we are plotting.
+    auto& filteredData = m_filteredData[kChartTitles[i]];
+    auto& rawData = m_rawData[kChartTitles[i]];
+
+    // Generate Sim vs Filtered Plot
     if (m_fitNextPlot[i]) {
       ImPlot::FitNextPlotAxes();
     }
@@ -346,25 +386,24 @@ bool AnalyzerPlot::DisplayTimeDomainPlots(ImVec2 plotSize) {
     }
     if (ImPlot::BeginPlot(kChartTitles[i], x, y, plotSize, ImPlotFlags_None,
                           ImPlotAxisFlags_NoGridLines)) {
-      // Get a reference to the data we are plotting.
-      auto& data = m_data[kChartTitles[i]];
-
       // Set Legend Location:
       ImPlot::SetLegendLocation(ImPlotLocation_NorthEast,
                                 ImPlotOrientation_Vertical, false);
 
-      ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
-      ImPlot::PlotScatterG("Collected Data", Getter, data.data(), data.size());
+      // Plot Raw and Filtered Data
+      PlotRawAndFiltered(rawData, filteredData);
 
       // Plot Simulation Data for Velocity Data
       if (isVelocity) {
         PlotSimData((i == 2) ? m_quasistaticSim : m_dynamicSim);
       }
-      ImPlot::EndPlot();
 
+      // Disable constant resizing for Accel Plot
       if (m_fitNextPlot[i]) {
         m_fitNextPlot[i] = false;
       }
+
+      ImPlot::EndPlot();
     }
   }
 
@@ -380,7 +419,7 @@ bool AnalyzerPlot::DisplayTimeDomainPlots(ImVec2 plotSize) {
                         plotSize, ImPlotFlags_None,
                         ImPlotAxisFlags_NoGridLines)) {
     // Get a reference to the data we are plotting.
-    auto& data = m_data[kChartTitles[6]];
+    auto& data = m_filteredData[kChartTitles[6]];
 
     ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
     ImPlot::PlotScatterG("Timesteps", Getter, data.data(), data.size());

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -61,10 +62,13 @@ class AnalysisManager {
     double motionThreshold = 0.2;
 
     /** The window size for computing acceleration */
-    int windowSize = 8;
+    int windowSize = 9;
 
     /** The dataset that is being analyzed. */
     int dataset = 0;
+
+    units::second_t stepTestDuration =
+        units::second_t{0.0};  // Indicate that it hasn't been set yet
 
     /** The conversion factors. These contain values to convert feedback gains
      * by gearing and cpr. */
@@ -102,8 +106,7 @@ class AnalysisManager {
    * @param settings The settings for this instance of the analysis manager.
    * @param logger   The logger instance to use for log data.
    */
-  AnalysisManager(wpi::StringRef path, const Settings& settings,
-                  wpi::Logger& logger);
+  AnalysisManager(wpi::StringRef path, Settings& settings, wpi::Logger& logger);
 
   /**
    * Prepares data from the JSON and stores the output in the StringMap.
@@ -154,13 +157,36 @@ class AnalysisManager {
   double GetFactor() const { return m_factor; }
 
   /**
-   * Returns a reference to the iterator of the currently selected datset.
+   * Returns a reference to the iterator of the currently selected raw datset.
    * Unfortunately, due to ImPlot internals, the reference cannot be const so
    * the user should be careful not to change any data.
    *
    * @return A reference to the raw internal data.
    */
-  Storage& GetRawData() { return m_datasets[kDatasets[m_settings.dataset]]; }
+  Storage& GetRawData() { return m_rawDatasets[kDatasets[m_settings.dataset]]; }
+
+  /**
+   * Returns a reference to the iterator of the currently selected filtered
+   * datset. Unfortunately, due to ImPlot internals, the reference cannot be
+   * const so the user should be careful not to change any data.
+   *
+   * @return A reference to the filtered internal data.
+   */
+  Storage& GetFilteredData() {
+    return m_filteredDatasets[kDatasets[m_settings.dataset]];
+  }
+
+  /**
+   * Returns the minimum duration of the Step Voltage Test of the currently
+   * stored data.
+   */
+  double GetMinDuration() const { return m_minDuration.to<double>(); }
+
+  /**
+   * Returns the maximum duration of the Step Voltage Test of the currently
+   * stored data.
+   */
+  double GetMaxDuration() const { return m_maxDuration.to<double>(); }
 
   /**
    * Returns the different start times of the recorded tests.
@@ -173,20 +199,24 @@ class AnalysisManager {
   // This is used to store the various datasets (i.e. Combined, Forward,
   // Backward, etc.)
   wpi::json m_json;
-  wpi::StringMap<Storage> m_datasets;
+  wpi::StringMap<Storage> m_rawDatasets;
+  wpi::StringMap<Storage> m_filteredDatasets;
 
   // Stores the various start times of the different tests.
   std::array<units::second_t, 4> m_startTimes;
 
   // The settings for this instance. This contains pointers to the feedback
   // controller preset, LQR parameters, acceleration window size, etc.
-  const Settings& m_settings;
+  Settings& m_settings;
 
   // Miscellaneous data from the JSON -- the analysis type, the units, and the
   // units per rotation.
   AnalysisType m_type;
   std::string m_unit;
   double m_factor;
+
+  units::second_t m_minDuration;
+  units::second_t m_maxDuration;
 
   // Stores an optional track width if we are doing the drivetrain angular test.
   std::optional<double> m_trackWidth;

--- a/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -1,0 +1,92 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+#include <frc/MedianFilter.h>
+
+#include "sysid/analysis/AnalysisManager.h"
+
+namespace sysid {
+
+/**
+ * Trims quasistatic data so that no point has a voltage of zero or a velocity
+ * less than the motion threshold.
+ *
+ * @tparam S        The size of the raw data array.
+ * @tparam Voltage  The index of the voltage entry in the raw data.
+ * @tparam Velocity The index of the velocity entry in the raw data.
+ *
+ * @param data            A pointer to the vector of raw data.
+ * @param motionThreshold The velocity threshold under which to delete data.
+ */
+template <size_t S, size_t Voltage, size_t Velocity>
+void TrimQuasistaticData(std::vector<std::array<double, S>>* data,
+                         double motionThreshold) {
+  data->erase(std::remove_if(data->begin(), data->end(),
+                             [motionThreshold](const auto& pt) {
+                               return std::abs(pt[Voltage]) <= 0 ||
+                                      std::abs(pt[Velocity]) < motionThreshold;
+                             }),
+              data->end());
+}
+
+/**
+ * Calculates the expected acceleration noise to be used as the floor of the
+ * Voltage Trim. This is done by taking the standard deviation from the moving
+ * average values of each point.
+ *
+ * @param data the prepared data vector containing acceleration data
+ * @param window the size of the window for the moving average
+ */
+double GetAccelNoiseFloor(const std::vector<PreparedData>& data, int window);
+
+/**
+ * Reduces noise in velocity data by applying a median filter.
+ *
+ * @tparam S The size of the raw data array
+ * @tparam Velocity The index of the velocity entry in the raw data.
+ *
+ * @param data the vector of arrays representing sysid data (must contain
+ * velocity data)
+ * @param window the size of the window of the median filter (must be odd)
+ */
+template <size_t S, size_t Velocity>
+std::vector<std::array<double, S>> ApplyMedianFilter(
+    const std::vector<std::array<double, S>>& data, int window) {
+  size_t step = window / 2;
+  std::vector<std::array<double, S>> prepared;
+  frc::MedianFilter<double> medianFilter(window);
+  for (size_t i = 0; i < data.size(); i++) {
+    std::array<double, S> latestData{data[i]};
+    double median = medianFilter.Calculate(latestData[Velocity]);
+    if (i > step) {
+      std::array<double, S> updateData{data[i - step]};
+      updateData[Velocity] = median;
+      prepared.push_back(updateData);
+    }
+  }
+
+  return prepared;
+}
+
+/**
+ * Trims the step voltage data to discard all points before the maximum
+ * acceleration and after reaching stead-state velocity.
+ *
+ * @param data A pointer to the step voltage data.
+ * @param stepTestDuration A reference to the step test duration that will be
+ * used.
+ * @param minStepTime A reference to the minimum step time that will be used.
+ */
+void TrimStepVoltageData(std::vector<PreparedData>* data,
+                         AnalysisManager::Settings& settings,
+                         units::second_t& minStepTime,
+                         units::second_t maxStepTime);
+}  // namespace sysid

--- a/src/main/native/include/sysid/view/Analyzer.h
+++ b/src/main/native/include/sysid/view/Analyzer.h
@@ -52,6 +52,14 @@ class Analyzer : public glass::View {
   void RefreshInformation();
   void AbortDataPrep();
 
+  /**
+   * Loads the diagnostic plots.
+   *
+   * @return returns true if the plots have already been loaded, false if they
+   * have just finished loading.
+   */
+  bool LoadPlots();
+
   bool first = true;
   std::string m_exception;
 
@@ -81,6 +89,7 @@ class Analyzer : public glass::View {
   AnalysisType m_type;
   int m_window = 8;
   double m_threshold = 0.2;
+  float m_stepTestDuration = 0.0;
 
   bool combinedGraphFit = false;
 

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -48,7 +48,8 @@ class AnalyzerPlot {
   /**
    * Sets the raw data to be displayed on the plots.
    */
-  void SetData(const Storage& data, const std::vector<double>& ff,
+  void SetData(const Storage& rawData, const Storage& filteredData,
+               const std::vector<double>& ff,
                const std::array<units::second_t, 4>& startTimes,
                AnalysisType type, std::atomic<bool>& abort);
 
@@ -77,7 +78,8 @@ class AnalyzerPlot {
   static constexpr size_t kMaxSize = 2048;
 
   // Stores ImPlotPoint vectors for all of the data.
-  wpi::StringMap<std::vector<ImPlotPoint>> m_data;
+  wpi::StringMap<std::vector<ImPlotPoint>> m_filteredData;
+  wpi::StringMap<std::vector<ImPlotPoint>> m_rawData;
 
   // Stores points for the lines of best fit.
   ImPlotPoint m_KvFit[2];

--- a/src/test/native/cpp/analysis/FilterTest.cpp
+++ b/src/test/native/cpp/analysis/FilterTest.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <array>
+#include <vector>
+
+#include <wpi/raw_ostream.h>
+
+#include "gtest/gtest.h"
+#include "sysid/analysis/AnalysisManager.h"
+#include "sysid/analysis/FeedforwardAnalysis.h"
+#include "sysid/analysis/FilteringUtils.h"
+
+TEST(FilterTest, MedianFilter) {
+  std::vector<std::array<double, 1>> testData = {{0}, {1},    {10}, {5}, {3},
+                                                 {0}, {1000}, {7},  {6}, {5}};
+  std::vector<std::array<double, 1>> expectedData = {{1}, {5}, {5}, {3},
+                                                     {3}, {7}, {7}, {6}};
+  std::vector<std::array<double, 1>> filteredData =
+      sysid::ApplyMedianFilter<1, 0>(testData, 3);
+  EXPECT_EQ(expectedData, filteredData);
+}
+
+TEST(FilterTest, QuasistaticTrim) {
+  std::vector<std::array<double, 2>> testData = {
+      {0, 1}, {.5, 2}, {2, 0.1}, {4, 4}, {0, 5}};
+  std::vector<std::array<double, 2>> expectedData = {{.5, 2}, {4, 4}};
+  sysid::TrimQuasistaticData<2, 0, 1>(&testData, 0.2);
+  EXPECT_EQ(expectedData, testData);
+}
+
+TEST(FilterTests, AccelNoiseFloor) {
+  std::vector<sysid::PreparedData> testData = {
+      {0_s, 1, 2, 3, 0, 0}, {1_s, 1, 2, 3, 1, 0},    {2_s, 1, 2, 3, 2, 0},
+      {3_s, 1, 2, 3, 5, 0}, {4_s, 1, 2, 3, 0.35, 0}, {5_s, 1, 2, 3, 0.15, 0},
+      {6_s, 1, 2, 3, 0, 0}, {7_s, 1, 2, 3, 0.02, 0}, {8_s, 1, 2, 3, 0.01, 0},
+      {9_s, 1, 2, 3, 0, 0}};
+  double noiseFloor = GetAccelNoiseFloor(testData, 2);
+  EXPECT_NEAR(0.953, noiseFloor, 0.001);
+}
+
+TEST(FilterTest, StepTrim) {
+  std::vector<sysid::PreparedData> testData = {
+      {0_s, 1, 2, 3, 0, 0},    {1_s, 1, 2, 3, 0.25, 0}, {2_s, 1, 2, 3, 0.5, 0},
+      {3_s, 1, 2, 3, 0.45, 0}, {4_s, 1, 2, 3, 0.35, 0}, {5_s, 1, 2, 3, 0.15, 0},
+      {6_s, 1, 2, 3, 0, 0},    {7_s, 1, 2, 3, 0.02, 0}, {8_s, 1, 2, 3, 0.01, 0},
+      {9_s, 1, 2, 3, 0, 0},
+  };
+
+  std::vector<sysid::PreparedData> expectedData = {{2_s, 1, 2, 3, 0.5, 0},
+                                                   {3_s, 1, 2, 3, 0.45, 0},
+                                                   {4_s, 1, 2, 3, 0.35, 0},
+                                                   {5_s, 1, 2, 3, 0.15, 0}};
+
+  auto maxTime = 9_s;
+  auto minTime = maxTime;
+
+  sysid::AnalysisManager::Settings settings;
+  sysid::TrimStepVoltageData(&testData, settings, minTime, maxTime);
+
+  EXPECT_EQ(expectedData[0].acceleration, testData[0].acceleration);
+  EXPECT_EQ(expectedData.back().acceleration, testData.back().acceleration);
+  EXPECT_EQ(5, settings.stepTestDuration.to<double>());
+  EXPECT_EQ(2, minTime.to<double>());
+}


### PR DESCRIPTION
Applies a median filter on the velocity data to remove outliers
Incorporates time trimming to allow teams to better trim their dynamic test data.
Resolves #75 

Issues:
- [x] Fix Graph scaling
- [x] Refactor Analyzer a bit more
- [x] Add tests?
- [x] Add graph legend
- [x] Setup Filtered, Raw, Simulate Graphs stuff

This should allow teams to significantly clean up noisy data.
Here's an example using the integration test flywheel sim with encoder noise set to 0.1:

### Time domain graphs (Left is current tool, Right is PR):
![image](https://user-images.githubusercontent.com/29788153/111881476-7fec2880-897e-11eb-8ea2-fd2a06357cc6.png)

### Voltage Domain Graphs (Left is current tool, Right is PR):
![image](https://user-images.githubusercontent.com/29788153/111881489-9a260680-897e-11eb-925f-de4d1f1af74e.png)

### Gains and Settings (Top is current tool, Bottom is PR):
![image](https://user-images.githubusercontent.com/29788153/111881512-ae6a0380-897e-11eb-87a4-f176afd642b9.png)

