### PR TITLE
Upload bad JSONs from integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,3 +36,10 @@ jobs:
 
       - name: Run Integration Tests
         run: ./gradlew runIntegrationTests -PwithIntegration
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Upload Bad Json
+          path: jsons/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,6 @@ gradle-app.setting
 .vim/
 .caches/
 .cache/
+
+# Failed JSONS
+jsons/

--- a/src/main/native/cpp/telemetry/TelemetryManager.cpp
+++ b/src/main/native/cpp/telemetry/TelemetryManager.cpp
@@ -249,7 +249,7 @@ std::string TelemetryManager::SaveJSON(wpi::StringRef location) {
   ss << location;
   ss << SYSID_PATH_SEPARATOR;
   ss << "sysid_data";
-  ss << std::put_time(&tm, "%Y%m%d-%H%M");
+  ss << std::put_time(&tm, "%Y%m%d-%H%M%S");
   ss << ".json";
 
   std::string loc = ss.str();


### PR DESCRIPTION
If the integration test fails, it will store the json of the failed
test and for CI it will upload them as artifacts for debugging purposes.

~~TODO: Remove part that fails all of the integration tests~~