### PR TITLE
Add dt plots

### DIFF
--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -185,7 +185,8 @@ static void CalculateCosine(std::vector<PreparedData>* data,
 static void PrepareGeneralData(const wpi::json& json,
                                const AnalysisManager::Settings& settings,
                                double factor, wpi::StringRef unit,
-                               wpi::StringMap<Storage>& datasets) {
+                               wpi::StringMap<Storage>& datasets,
+                               std::array<double, 4>& startTimes) {
   using Data = std::array<double, 4>;
   wpi::StringMap<std::vector<Data>> data;
 
@@ -242,6 +243,8 @@ static void PrepareGeneralData(const wpi::json& json,
   datasets["Backward"] = std::make_tuple(sb, fb);
   datasets["Combined"] =
       std::make_tuple(Concatenate(sf, {&sb}), Concatenate(ff, {&fb}));
+  startTimes = {sf[0].timestamp, sb[0].timestamp, ff[0].timestamp,
+                fb[0].timestamp};
 }
 
 /**
@@ -261,8 +264,8 @@ static void PrepareGeneralData(const wpi::json& json,
  */
 static void PrepareAngularDrivetrainData(
     const wpi::json& json, const AnalysisManager::Settings& settings,
-    double factor, std::optional<double>& tw,
-    wpi::StringMap<Storage>& datasets) {
+    double factor, std::optional<double>& tw, wpi::StringMap<Storage>& datasets,
+    std::array<double, 4>& startTimes) {
   using Data = std::array<double, 9>;
   wpi::StringMap<std::vector<Data>> data;
 
@@ -322,6 +325,8 @@ static void PrepareAngularDrivetrainData(
   datasets["Backward"] = std::make_tuple(sb, fb);
   datasets["Combined"] =
       std::make_tuple(Concatenate(sf, {&sb}), Concatenate(ff, {&fb}));
+  startTimes = {sf[0].timestamp, sb[0].timestamp, ff[0].timestamp,
+                fb[0].timestamp};
 }
 
 /**
@@ -339,7 +344,8 @@ static void PrepareAngularDrivetrainData(
  */
 static void PrepareLinearDrivetrainData(
     const wpi::json& json, const AnalysisManager::Settings& settings,
-    double factor, wpi::StringMap<Storage>& datasets) {
+    double factor, wpi::StringMap<Storage>& datasets,
+    std::array<double, 4>& startTimes) {
   using Data = std::array<double, 9>;
   wpi::StringMap<std::vector<Data>> data;
 
@@ -425,6 +431,8 @@ static void PrepareLinearDrivetrainData(
   datasets["Right Backward"] = std::make_tuple(sbr, fbr);
   datasets["Right Combined"] =
       std::make_tuple(Concatenate(sfr, {&sbr}), Concatenate(ffr, {&fbr}));
+  startTimes = {sf[0].timestamp, sb[0].timestamp, ff[0].timestamp,
+                fb[0].timestamp};
 }
 
 AnalysisManager::AnalysisManager(wpi::StringRef path, const Settings& settings,
@@ -461,12 +469,14 @@ AnalysisManager::AnalysisManager(wpi::StringRef path, const Settings& settings,
 
 void AnalysisManager::PrepareData() {
   if (m_type == analysis::kDrivetrain) {
-    PrepareLinearDrivetrainData(m_json, m_settings, m_factor, m_datasets);
+    PrepareLinearDrivetrainData(m_json, m_settings, m_factor, m_datasets,
+                                m_startTimes);
   } else if (m_type == analysis::kDrivetrainAngular) {
     PrepareAngularDrivetrainData(m_json, m_settings, m_factor, m_trackWidth,
-                                 m_datasets);
+                                 m_datasets, m_startTimes);
   } else {
-    PrepareGeneralData(m_json, m_settings, m_factor, m_unit, m_datasets);
+    PrepareGeneralData(m_json, m_settings, m_factor, m_unit, m_datasets,
+                       m_startTimes);
   }
 }
 

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -203,8 +203,10 @@ void Analyzer::Display() {
         ImGui::SetCursorPosX(ImGui::GetFontSize() * 15);
         if (ImGui::Button(text)) {
           ImGui::OpenPopup(text);
-          std::thread thr{
-              [&] { m_plot.SetData(m_manager->GetRawData(), m_ff, m_type); }};
+          std::thread thr{[&] {
+            m_plot.SetData(m_manager->GetRawData(), m_manager->GetStartTimes(),
+                           m_ff, m_type);
+          }};
           thr.detach();
         }
       };

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -28,7 +28,8 @@ static ImPlotPoint Getter(void* data, int idx) {
 
 template <typename Model>
 static std::vector<std::vector<ImPlotPoint>> PopulateTimeDomainSim(
-    const std::vector<PreparedData>& data, size_t step, Model model) {
+    const std::vector<PreparedData>& data,
+    const std::array<double, 4>& startTimes, size_t step, Model model) {
   // Create the vector of ImPlotPoints that will contain our simulated data.
   std::vector<std::vector<ImPlotPoint>> pts;
   std::vector<ImPlotPoint> tmp;
@@ -44,12 +45,15 @@ static std::vector<std::vector<ImPlotPoint>> PopulateTimeDomainSim(
     auto dt = units::second_t{now.timestamp} - units::second_t{pre.timestamp};
     t += dt;
 
-    // If there's a large gap or the time went backwards, it's a new
-    // section of data, so reset the model state
-    if (dt < 0_s || dt > 1_s) {
-      pts.emplace_back(std::move(tmp));
-      model.Reset(now.position, now.velocity);
-      continue;
+    // If the current time stamp and previous time stamp are across a test's
+    // start timestamp, it is the start of a new test and the model needs to be
+    // reset.
+    for (const auto& startTime : startTimes) {
+      if (now.timestamp >= startTime && pre.timestamp <= startTime) {
+        pts.emplace_back(std::move(tmp));
+        model.Reset(now.position, now.velocity);
+        continue;
+      }
     }
 
     model.Update(units::volt_t{pre.voltage}, dt);
@@ -67,8 +71,9 @@ AnalyzerPlot::AnalyzerPlot(wpi::Logger& logger) : m_logger(logger) {
   }
 }
 
-void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
-                           AnalysisType type) {
+void AnalyzerPlot::SetData(const Storage& data,
+                           const std::array<double, 4>& startTimes,
+                           const std::vector<double>& ff, AnalysisType type) {
   std::scoped_lock lock(m_mutex);
   auto& [slow, fast] = data;
 
@@ -104,6 +109,8 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
         return a.acceleration < b.acceleration;
       })->acceleration;
 
+  int dtSamples = 0;
+  double dtSum = 0;
   // Populate quasistatic time-domain graphs and quasistatic velocity vs.
   // velocity-portion voltage graph.
   double t = slow[0].timestamp;
@@ -127,6 +134,21 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
                                          slow[i].velocity);
     m_data[kChartTitles[3]].emplace_back(slow[i].timestamp - t,
                                          slow[i].acceleration);
+
+    if (i > 0) {
+      // If the current timestamp is not in the startTimes array, it is the
+      // during a test and should be included. If it is in the startTimes array,
+      // it is the beginning of a new test and the dt will be inflated.
+      // Therefore we skip those to exclude that dt and effectively reset dt
+      // calculations.
+      if (std::find(startTimes.begin(), startTimes.end(), slow[i].timestamp) ==
+          startTimes.end()) {
+        double dt = (slow[i].timestamp - slow[i - 1].timestamp) * 1000;
+        m_data[kChartTitles[6]].emplace_back(slow[i].timestamp - t, dt);
+        dtSum += dt;
+        ++dtSamples;
+      }
+    }
   }
 
   // Populate dynamic time-domain graphs and dynamic acceleration vs.
@@ -152,24 +174,51 @@ void AnalyzerPlot::SetData(const Storage& data, const std::vector<double>& ff,
                                          fast[i].velocity);
     m_data[kChartTitles[5]].emplace_back(fast[i].timestamp - t,
                                          fast[i].acceleration);
+    if (i > 0) {
+      // If the current timestamp is not in the startTimes array, it is the
+      // during a test and should be included. If it is in the startTimes array,
+      // it is the beginning of a new test and the dt will be inflated.
+      // Therefore we skip those to exclude that dt and effectively reset dt
+      // calculations.
+      if (std::find(startTimes.begin(), startTimes.end(), fast[i].timestamp) ==
+          startTimes.end()) {
+        double dt = (fast[i].timestamp - fast[i - 1].timestamp) * 1000;
+        m_data[kChartTitles[6]].emplace_back(fast[i].timestamp - t, dt);
+        dtSum += dt;
+        ++dtSamples;
+      }
+    }
   }
+
+  // Load dt mean for plot data
+  double dtMean = dtSum / dtSamples;
+  m_dtMaxTime = std::max(slow.back().timestamp - slow.front().timestamp,
+                         fast.back().timestamp - fast.front().timestamp);
+
+  // Set first recorded timestamp to mean
+  m_dtMeanLine.emplace_back(0.0, dtMean);
+
+  // Set last recorded timestamp to mean
+  m_dtMeanLine.emplace_back(m_dtMaxTime, dtMean);
 
   // Populate simulated time-domain data.
   if (type == analysis::kElevator) {
-    m_quasistaticSim = PopulateTimeDomainSim(
-        slow, fStep, sysid::ElevatorSim{ff[0], ff[1], ff[2], ff[3]});
-    m_dynamicSim = PopulateTimeDomainSim(
-        fast, fStep, sysid::ElevatorSim{ff[0], ff[1], ff[2], ff[3]});
+    m_quasistaticSim =
+        PopulateTimeDomainSim(slow, startTimes, fStep,
+                              sysid::ElevatorSim{ff[0], ff[1], ff[2], ff[3]});
+    m_dynamicSim =
+        PopulateTimeDomainSim(fast, startTimes, fStep,
+                              sysid::ElevatorSim{ff[0], ff[1], ff[2], ff[3]});
   } else if (type == analysis::kArm) {
     m_quasistaticSim = PopulateTimeDomainSim(
-        slow, fStep, sysid::ArmSim{ff[0], ff[1], ff[2], ff[3]});
+        slow, startTimes, fStep, sysid::ArmSim{ff[0], ff[1], ff[2], ff[3]});
     m_dynamicSim = PopulateTimeDomainSim(
-        fast, fStep, sysid::ArmSim{ff[0], ff[1], ff[2], ff[3]});
+        fast, startTimes, fStep, sysid::ArmSim{ff[0], ff[1], ff[2], ff[3]});
   } else {
     m_quasistaticSim = PopulateTimeDomainSim(
-        slow, fStep, sysid::SimpleMotorSim{ff[0], ff[1], ff[2]});
+        slow, startTimes, fStep, sysid::SimpleMotorSim{ff[0], ff[1], ff[2]});
     m_dynamicSim = PopulateTimeDomainSim(
-        fast, fStep, sysid::SimpleMotorSim{ff[0], ff[1], ff[2]});
+        fast, startTimes, fStep, sysid::SimpleMotorSim{ff[0], ff[1], ff[2]});
   }
 
   // Set the "fit" flag to true.
@@ -276,6 +325,30 @@ void AnalyzerPlot::DisplayTimeDomainPlots() {
       if (m_fitNextPlot[i]) {
         m_fitNextPlot[i] = false;
       }
+    }
+  }
+  if (m_fitNextPlot[6]) {
+    ImPlot::SetNextPlotLimits(0, m_dtMaxTime, 0, 50);
+    ImPlot::FitNextPlotAxes(true, false, false, false);
+  }
+  if (ImPlot::BeginPlot(kChartTitles[6], "Time (s)", "Change in Time (ms)",
+                        ImVec2(-1, 0), ImPlotFlags_None,
+                        ImPlotAxisFlags_NoGridLines)) {
+    // Get a reference to the data we are plotting.
+    auto& data = m_data[kChartTitles[6]];
+
+    ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
+    ImPlot::PlotScatterG("", Getter, data.data(), data.size());
+
+    ImPlot::SetNextMarkerStyle(IMPLOT_AUTO, 1, IMPLOT_AUTO_COL, 0);
+
+    ImPlot::PlotLineG("Mean dt", Getter, m_dtMeanLine.data(),
+                      m_dtMeanLine.size());
+
+    ImPlot::EndPlot();
+
+    if (m_fitNextPlot[6]) {
+      m_fitNextPlot[6] = false;
     }
   }
 }

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -328,7 +328,7 @@ void AnalyzerPlot::DisplayTimeDomainPlots() {
     }
   }
   if (m_fitNextPlot[6]) {
-    ImPlot::SetNextPlotLimits(0, m_dtMaxTime, 0, 50);
+    ImPlot::SetNextPlotLimitsY(0, 50);
     ImPlot::FitNextPlotAxes(true, false, false, false);
   }
   if (ImPlot::BeginPlot(kChartTitles[6], "Time (s)", "Change in Time (ms)",

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -161,6 +161,11 @@ class AnalysisManager {
    */
   Storage& GetRawData() { return m_datasets[kDatasets[m_settings.dataset]]; }
 
+  /**
+   * Returns the different start times of the recorded tests.
+   */
+  const std::array<double, 4> GetStartTimes() { return m_startTimes; }
+
  private:
   wpi::Logger& m_logger;
 
@@ -168,6 +173,9 @@ class AnalysisManager {
   // Backward, etc.)
   wpi::json m_json;
   wpi::StringMap<Storage> m_datasets;
+
+  // Stores the various start times of the different tests.
+  std::array<double, 4> m_startTimes;
 
   // The settings for this instance. This contains pointers to the feedback
   // controller preset, LQR parameters, acceleration window size, etc.

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -31,7 +31,8 @@ class AnalyzerPlot {
       "Quasistatic Velocity vs. Time",
       "Quasistatic Acceleration vs. Time",
       "Dynamic Velocity vs. Time",
-      "Dynamic Acceleration vs. Time"};
+      "Dynamic Acceleration vs. Time",
+      "Timesteps vs. Time"};
 
   /**
    * Constructs an instance of the analyzer plot helper and allocates memory for
@@ -42,8 +43,8 @@ class AnalyzerPlot {
   /**
    * Sets the raw data to be displayed on the plots.
    */
-  void SetData(const Storage& data, const std::vector<double>& ff,
-               AnalysisType type);
+  void SetData(const Storage& data, const std::array<double, 4>& startTimes,
+               const std::vector<double>& ff, AnalysisType type);
 
   /**
    * Displays voltage-domain plots.
@@ -69,6 +70,11 @@ class AnalyzerPlot {
   // Stores points for simulated time-domain data.
   std::vector<std::vector<ImPlotPoint>> m_quasistaticSim;
   std::vector<std::vector<ImPlotPoint>> m_dynamicSim;
+
+  // Stores differences in time deltas
+  std::vector<std::vector<ImPlotPoint>> m_dt;
+  std::vector<ImPlotPoint> m_dtMeanLine;
+  double m_dtMaxTime = 0.0;
 
   // Thread safety
   wpi::spinlock m_mutex;


### PR DESCRIPTION
- Adds diagnostic plots to see the timing of data collection
- Stores test start positions for more robust identification of times
between tests

Example graph:
![image](https://user-images.githubusercontent.com/29788153/113172730-51880c00-920e-11eb-9e26-807ed26dc25e.png)
