### PR TITLE
Add a screenshot-friendly combined diagnostics plot view

### DIFF
--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -193,7 +193,6 @@ void Analyzer::Display() {
       }
 
       ShowGain("r-squared", &m_rs);
-      float endY = ImGui::GetCursorPosY();
 
       // Come back to the starting y pos.
       ImGui::SetCursorPosY(beginY);
@@ -213,6 +212,7 @@ void Analyzer::Display() {
 
       ShowDiagnostics("Voltage-Domain Diagnostics");
       ShowDiagnostics("Time-Domain Diagnostics");
+      ShowDiagnostics("Combined Diagnostics");
 
       ImGui::SetCursorPosX(ImGui::GetFontSize() * 15);
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
@@ -233,6 +233,8 @@ void Analyzer::Display() {
         Calculate();
       }
 
+      float endY = ImGui::GetCursorPosY();
+
       auto size = ImGui::GetIO().DisplaySize;
       ImGui::SetNextWindowSize(ImVec2(size.x / 2.5, size.y * 0.9));
 
@@ -251,6 +253,19 @@ void Analyzer::Display() {
       // Show time domain diagnostic plots.
       if (ImGui::BeginPopupModal("Time-Domain Diagnostics")) {
         m_plot.DisplayTimeDomainPlots();
+        // Button to close popup.
+        if (ImGui::Button("Close")) {
+          ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+      }
+
+      ImGui::SetNextWindowSize(ImVec2(m_plot.kCombinedPlotSize * 4 + 50,
+                                      m_plot.kCombinedPlotSize * 2 + 25));
+      // Show plots for screenshots
+      if (ImGui::BeginPopupModal("Combined Diagnostics")) {
+        m_plot.DisplayCombinedPlots();
+
         // Button to close popup.
         if (ImGui::Button("Close")) {
           ImGui::CloseCurrentPopup();

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <vector>
 
+#include <imgui.h>
 #include <implot.h>
 #include <units/time.h>
 #include <units/voltage.h>
@@ -34,6 +35,9 @@ class AnalyzerPlot {
       "Dynamic Acceleration vs. Time",
       "Timesteps vs. Time"};
 
+  // Size of plots when screenshotting
+  static constexpr int kCombinedPlotSize = 300;
+
   /**
    * Constructs an instance of the analyzer plot helper and allocates memory for
    * all data vectors.
@@ -49,12 +53,14 @@ class AnalyzerPlot {
   /**
    * Displays voltage-domain plots.
    */
-  void DisplayVoltageDomainPlots();
+  void DisplayVoltageDomainPlots(ImVec2 plotSize = ImVec2(-1, 0));
 
   /**
    * Displays time-domain plots.
    */
-  void DisplayTimeDomainPlots();
+  void DisplayTimeDomainPlots(ImVec2 plotSize = ImVec2(-1, 0));
+
+  void DisplayCombinedPlots();
 
  private:
   // The maximum size of each vector (dataset to plot).


### PR DESCRIPTION
Adds an option for a grid popup to make it easier to screenshot all the graphs.
e.g:
![image](https://user-images.githubusercontent.com/29788153/113821807-37848700-9742-11eb-92ca-9a29da167916.png)
