### PR TITLE
Increase Ka tolerance in integration tests

### DIFF
--- a/src/integrationtest/native/cpp/SimulationTest.cpp
+++ b/src/integrationtest/native/cpp/SimulationTest.cpp
@@ -118,7 +118,7 @@ class IntegrationTest : public ::testing::Test {
                   << "Kv: " << ff[1] << "\nKa: " << ff[2] << "\n";
       wpi::outs().flush();
       EXPECT_NEAR(Kv, ff[1], 0.30);
-      EXPECT_NEAR(Ka, ff[2], 0.15);
+      EXPECT_NEAR(Ka, ff[2], 0.20);
 
       if (m_settings.mechanism == sysid::analysis::kElevator) {
         wpi::outs() << "KG: " << ff[3] << "\n";


### PR DESCRIPTION
Ka is affected by poor timing and CI timing is not consistent at all. As
long as this value is relatively close enough, it should be okay for the
integration tests. There are more rigorous unit tests that also test the
gain calculation logic.