### PR TITLE
Fix handling of start times and negative time deltas

### DIFF
--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -95,8 +95,8 @@ std::vector<PreparedData> ComputeAcceleration(
     // Sometimes, if the encoder velocities are the same, it will register zero
     // acceleration. Do not include these values.
     if (acc != 0) {
-      prepared.push_back(PreparedData{pt[0], pt[Voltage], pt[Position],
-                                      pt[Velocity], acc, 0.0});
+      prepared.push_back(PreparedData{units::second_t{pt[0]}, pt[Voltage],
+                                      pt[Position], pt[Velocity], acc, 0.0});
     }
   }
   return prepared;
@@ -186,7 +186,7 @@ static void PrepareGeneralData(const wpi::json& json,
                                const AnalysisManager::Settings& settings,
                                double factor, wpi::StringRef unit,
                                wpi::StringMap<Storage>& datasets,
-                               std::array<double, 4>& startTimes) {
+                               std::array<units::second_t, 4>& startTimes) {
   using Data = std::array<double, 4>;
   wpi::StringMap<std::vector<Data>> data;
 
@@ -265,7 +265,7 @@ static void PrepareGeneralData(const wpi::json& json,
 static void PrepareAngularDrivetrainData(
     const wpi::json& json, const AnalysisManager::Settings& settings,
     double factor, std::optional<double>& tw, wpi::StringMap<Storage>& datasets,
-    std::array<double, 4>& startTimes) {
+    std::array<units::second_t, 4>& startTimes) {
   using Data = std::array<double, 9>;
   wpi::StringMap<std::vector<Data>> data;
 
@@ -345,7 +345,7 @@ static void PrepareAngularDrivetrainData(
 static void PrepareLinearDrivetrainData(
     const wpi::json& json, const AnalysisManager::Settings& settings,
     double factor, wpi::StringMap<Storage>& datasets,
-    std::array<double, 4>& startTimes) {
+    std::array<units::second_t, 4>& startTimes) {
   using Data = std::array<double, 9>;
   wpi::StringMap<std::vector<Data>> data;
 

--- a/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <vector>
 
+#include <units/time.h>
 #include <wpi/Logger.h>
 #include <wpi/StringMap.h>
 #include <wpi/StringRef.h>
@@ -26,7 +27,7 @@ namespace sysid {
  * calculated.
  */
 struct PreparedData {
-  double timestamp;
+  units::second_t timestamp;
   double voltage;
   double position;
   double velocity;
@@ -164,7 +165,7 @@ class AnalysisManager {
   /**
    * Returns the different start times of the recorded tests.
    */
-  const std::array<double, 4> GetStartTimes() { return m_startTimes; }
+  const std::array<units::second_t, 4> GetStartTimes() { return m_startTimes; }
 
  private:
   wpi::Logger& m_logger;
@@ -175,7 +176,7 @@ class AnalysisManager {
   wpi::StringMap<Storage> m_datasets;
 
   // Stores the various start times of the different tests.
-  std::array<double, 4> m_startTimes;
+  std::array<units::second_t, 4> m_startTimes;
 
   // The settings for this instance. This contains pointers to the feedback
   // controller preset, LQR parameters, acceleration window size, etc.

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -49,8 +49,8 @@ class AnalyzerPlot {
    * Sets the raw data to be displayed on the plots.
    */
   void SetData(const Storage& data, const std::vector<double>& ff,
-               const std::array<double, 4>& startTimes, AnalysisType type,
-               std::atomic<bool>& abort);
+               const std::array<units::second_t, 4>& startTimes,
+               AnalysisType type, std::atomic<bool>& abort);
 
   /**
    * Displays voltage-domain plots.

--- a/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
+++ b/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
@@ -36,9 +36,8 @@ sysid::Storage CollectData(Model& model) {
   auto voltage = 0_V;
   for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
     slow.emplace_back(sysid::PreparedData{
-        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
-        model.GetVelocity(), model.GetAcceleration(voltage),
-        std::cos(model.GetPosition())});
+        i * T, voltage.to<double>(), model.GetPosition(), model.GetVelocity(),
+        model.GetAcceleration(voltage), std::cos(model.GetPosition())});
 
     model.Update(voltage, T);
     voltage += kUstep * T;
@@ -49,9 +48,8 @@ sysid::Storage CollectData(Model& model) {
   voltage = 0_V;
   for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
     slow.emplace_back(sysid::PreparedData{
-        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
-        model.GetVelocity(), model.GetAcceleration(voltage),
-        std::cos(model.GetPosition())});
+        i * T, voltage.to<double>(), model.GetPosition(), model.GetVelocity(),
+        model.GetAcceleration(voltage), std::cos(model.GetPosition())});
 
     model.Update(voltage, T);
     voltage -= kUstep * T;
@@ -62,9 +60,8 @@ sysid::Storage CollectData(Model& model) {
   voltage = 0_V;
   for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
     fast.emplace_back(sysid::PreparedData{
-        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
-        model.GetVelocity(), model.GetAcceleration(voltage),
-        std::cos(model.GetPosition())});
+        i * T, voltage.to<double>(), model.GetPosition(), model.GetVelocity(),
+        model.GetAcceleration(voltage), std::cos(model.GetPosition())});
 
     model.Update(voltage, T);
     voltage = kUmax;
@@ -75,9 +72,8 @@ sysid::Storage CollectData(Model& model) {
   voltage = 0_V;
   for (int i = 0; i < (kTestDuration / T).to<double>(); ++i) {
     fast.emplace_back(sysid::PreparedData{
-        (i * T).to<double>(), voltage.to<double>(), model.GetPosition(),
-        model.GetVelocity(), model.GetAcceleration(voltage),
-        std::cos(model.GetPosition())});
+        i * T, voltage.to<double>(), model.GetPosition(), model.GetVelocity(),
+        model.GetAcceleration(voltage), std::cos(model.GetPosition())});
 
     model.Update(voltage, T);
     voltage = -kUmax;


### PR DESCRIPTION
This resets the simulation model if a dataset start time is encountered
or dt < 0. dt >= 0 should be an invariant in the data, but it's better
to make the plots robust to it anyway.

Uses of double were replaced with units::second_t since we're here.

The sim still isn't great, but at least it's not completely unstable. The data's not the cleanest, so maybe that has something to do with it.

Before:
![before](https://user-images.githubusercontent.com/2748555/114466480-644ef900-9b9d-11eb-8f33-f6256fe91b2c.png)

After:
![after](https://user-images.githubusercontent.com/2748555/114466497-6913ad00-9b9d-11eb-85e7-9d07955d00f3.png)


[negative-dt-20210409-185818.json.txt](https://github.com/wpilibsuite/sysid/files/6299958/negative-dt-20210409-185818.json.txt)

