### PR TITLE
Refactor dt filtering and tighten integration test tolerances

### DIFF
--- a/src/integrationtest/native/cpp/SimulationTest.cpp
+++ b/src/integrationtest/native/cpp/SimulationTest.cpp
@@ -116,17 +116,24 @@ class IntegrationTest : public ::testing::Test {
       wpi::outs() << "Ks: " << ffGains[0] << "\n"
                   << "Kv: " << ffGains[1] << "\nKa: " << ffGains[2] << "\n";
       wpi::outs().flush();
-      EXPECT_NEAR(Kv, ffGains[1], 0.05);
-      EXPECT_NEAR(Ka, ffGains[2], 0.20);
+      if (m_settings.mechanism == sysid::analysis::kArm) {
+        // The acceleration fit (used only for arms) is worse than the next
+        // velocity fit
+        EXPECT_NEAR(Kv, ffGains[1], 0.015);
+        EXPECT_NEAR(Ka, ffGains[2], 0.025);
+      } else {
+        EXPECT_NEAR(Kv, ffGains[1], 0.003);
+        EXPECT_NEAR(Ka, ffGains[2], 0.003);
+      }
 
       if (m_settings.mechanism == sysid::analysis::kElevator) {
         wpi::outs() << "KG: " << ffGains[3] << "\n";
         wpi::outs().flush();
-        EXPECT_NEAR(kG, ffGains[3], 0.2);
+        EXPECT_NEAR(kG, ffGains[3], 0.003);
       } else if (m_settings.mechanism == sysid::analysis::kArm) {
         wpi::outs() << "KCos: " << ffGains[3] << "\n";
         wpi::outs().flush();
-        EXPECT_NEAR(kCos, ffGains[3], 0.15);
+        EXPECT_NEAR(kCos, ffGains[3], 0.025);
       }
 
       if (trackWidth) {

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -164,10 +164,9 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // it is the beginning of a new test and the dt will be inflated.
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
-      auto dt = slow[i].timestamp - slow[i - 1].timestamp;
       if (std::find(startTimes.begin(), startTimes.end(), slow[i].timestamp) ==
-              startTimes.end() &&
-          dt > 0_s && dt < 500_ms) {
+          startTimes.end()) {
+        auto dt = slow[i].timestamp - slow[i - 1].timestamp;
         m_filteredData[kChartTitles[6]].emplace_back(
             (slow[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
@@ -210,10 +209,9 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // it is the beginning of a new test and the dt will be inflated.
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
-      auto dt = fast[i].timestamp - fast[i - 1].timestamp;
       if (std::find(startTimes.begin(), startTimes.end(), fast[i].timestamp) ==
-              startTimes.end() &&
-          dt > 0_s && dt < 500_ms) {
+          startTimes.end()) {
+        auto dt = fast[i].timestamp - fast[i - 1].timestamp;
         m_filteredData[kChartTitles[6]].emplace_back(
             (fast[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -20,6 +20,7 @@
 #include "sysid/analysis/AnalysisType.h"
 #include "sysid/analysis/ArmSim.h"
 #include "sysid/analysis/ElevatorSim.h"
+#include "sysid/analysis/FilteringUtils.h"
 #include "sysid/analysis/SimpleMotorSim.h"
 
 using namespace sysid;
@@ -126,8 +127,8 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
         return a.acceleration < b.acceleration;
       })->acceleration;
 
-  int dtSamples = 0;
-  auto dtSum = 0_s;
+  units::second_t dtMean = GetMeanTimeDelta(filteredData);
+
   // Populate quasistatic time-domain graphs and quasistatic velocity vs.
   // velocity-portion voltage graph.
   auto t = slow[0].timestamp;
@@ -163,14 +164,13 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // it is the beginning of a new test and the dt will be inflated.
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
+      auto dt = slow[i].timestamp - slow[i - 1].timestamp;
       if (std::find(startTimes.begin(), startTimes.end(), slow[i].timestamp) ==
-          startTimes.end()) {
-        auto dt = slow[i].timestamp - slow[i - 1].timestamp;
+              startTimes.end() &&
+          dt > 0_s && dt < 500_ms) {
         m_filteredData[kChartTitles[6]].emplace_back(
             (slow[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
-        dtSum += dt;
-        ++dtSamples;
       }
     }
   }
@@ -211,19 +211,16 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
       auto dt = fast[i].timestamp - fast[i - 1].timestamp;
-      if (dt > 0_s && std::find(startTimes.begin(), startTimes.end(),
-                                fast[i].timestamp) == startTimes.end()) {
+      if (std::find(startTimes.begin(), startTimes.end(), fast[i].timestamp) ==
+              startTimes.end() &&
+          dt > 0_s && dt < 500_ms) {
         m_filteredData[kChartTitles[6]].emplace_back(
             (fast[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
-        dtSum += dt;
-        ++dtSamples;
       }
     }
   }
 
-  // Load dt mean for plot data
-  auto dtMean = dtSum / dtSamples;
   auto maxTime =
       units::math::max(slow.back().timestamp - slow.front().timestamp,
                        fast.back().timestamp - fast.front().timestamp);

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -164,9 +164,9 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // it is the beginning of a new test and the dt will be inflated.
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
-      if (std::find(startTimes.begin(), startTimes.end(), slow[i].timestamp) ==
-          startTimes.end()) {
-        auto dt = slow[i].timestamp - slow[i - 1].timestamp;
+      auto dt = slow[i].timestamp - slow[i - 1].timestamp;
+      if (dt > 0_s && std::find(startTimes.begin(), startTimes.end(),
+                                slow[i].timestamp) == startTimes.end()) {
         m_filteredData[kChartTitles[6]].emplace_back(
             (slow[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());
@@ -209,9 +209,9 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
       // it is the beginning of a new test and the dt will be inflated.
       // Therefore we skip those to exclude that dt and effectively reset dt
       // calculations.
-      if (std::find(startTimes.begin(), startTimes.end(), fast[i].timestamp) ==
-          startTimes.end()) {
-        auto dt = fast[i].timestamp - fast[i - 1].timestamp;
+      auto dt = fast[i].timestamp - fast[i - 1].timestamp;
+      if (dt > 0_s && std::find(startTimes.begin(), startTimes.end(),
+                                fast[i].timestamp) == startTimes.end()) {
         m_filteredData[kChartTitles[6]].emplace_back(
             (fast[i].timestamp - t).to<double>(),
             units::millisecond_t{dt}.to<double>());

--- a/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -10,8 +10,10 @@
 #include <vector>
 
 #include <frc/MedianFilter.h>
+#include <units/time.h>
 
 #include "sysid/analysis/AnalysisManager.h"
+#include "sysid/analysis/Storage.h"
 
 namespace sysid {
 
@@ -89,4 +91,10 @@ void TrimStepVoltageData(std::vector<PreparedData>* data,
                          AnalysisManager::Settings& settings,
                          units::second_t& minStepTime,
                          units::second_t maxStepTime);
+
+/**
+ * Compute the mean time delta of the given data.
+ */
+units::second_t GetMeanTimeDelta(const Storage& data);
+
 }  // namespace sysid


### PR DESCRIPTION
Time deltas in the range 0ms to 500ms are used to compute the mean time
delta. Then, data points are only considered that are within 1ms of that
mean.