### PR TITLE
Add JSON to CSV Converter

### DIFF
--- a/src/main/native/cpp/Main.cpp
+++ b/src/main/native/cpp/Main.cpp
@@ -132,9 +132,13 @@ int main() {
     }
 
     bool frcCharConvert = false;
+    bool toCSV = false;
     if (ImGui::BeginMenu("JSON Converters")) {
       if (ImGui::MenuItem("FRC-Char Converter")) {
         frcCharConvert = true;
+      }
+      if (ImGui::MenuItem("JSON to CSV Converter")) {
+        toCSV = true;
       }
 
       ImGui::EndMenu();
@@ -147,8 +151,21 @@ int main() {
       frcCharConvert = false;
     }
 
+    if (toCSV) {
+      ImGui::OpenPopup("SysId JSON to CSV Converter");
+      toCSV = false;
+    }
+
     if (ImGui::BeginPopupModal("FRC-Char Converter")) {
-      gJSONConverter->Display();
+      gJSONConverter->DisplayFRCCharConvert();
+      if (ImGui::Button("Close")) {
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
+    }
+
+    if (ImGui::BeginPopupModal("SysId JSON to CSV Converter")) {
+      gJSONConverter->DisplayCSVConvert();
       if (ImGui::Button("Close")) {
         ImGui::CloseCurrentPopup();
       }

--- a/src/main/native/cpp/Util.cpp
+++ b/src/main/native/cpp/Util.cpp
@@ -36,7 +36,7 @@ std::vector<std::string> sysid::Split(const std::string& s, char c) {
   return result;
 }
 
-std::string sysid::GetAbbreviation(std::string unit) {
+std::string sysid::GetAbbreviation(const std::string& unit) {
   if (unit == "Meters") {
     return "m";
   } else if (unit == "Feet") {

--- a/src/main/native/cpp/Util.cpp
+++ b/src/main/native/cpp/Util.cpp
@@ -5,6 +5,7 @@
 #include "sysid/Util.h"
 
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -33,4 +34,22 @@ std::vector<std::string> sysid::Split(const std::string& s, char c) {
   }
 
   return result;
+}
+
+std::string sysid::GetAbbreviation(std::string unit) {
+  if (unit == "Meters") {
+    return "m";
+  } else if (unit == "Feet") {
+    return "ft";
+  } else if (unit == "Inches") {
+    return "in";
+  } else if (unit == "Radians") {
+    return "rad";
+  } else if (unit == "Degrees") {
+    return "deg";
+  } else if (unit == "Rotations") {
+    return "rot";
+  } else {
+    throw std::runtime_error("Invalid Unit");
+  }
 }

--- a/src/main/native/cpp/analysis/JSONConverter.cpp
+++ b/src/main/native/cpp/analysis/JSONConverter.cpp
@@ -14,6 +14,7 @@
 #include <wpi/raw_istream.h>
 #include <wpi/raw_ostream.h>
 
+#include "sysid/Util.h"
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/AnalysisType.h"
 
@@ -30,7 +31,7 @@ static constexpr size_t kRPosCol = 6;
 static constexpr size_t kLVelCol = 7;
 static constexpr size_t kRVelCol = 8;
 
-std::string sysid::ConvertJSON(wpi::StringRef path, wpi::Logger& logger) {
+static wpi::json GetJSON(wpi::StringRef path, wpi::Logger& logger) {
   std::error_code ec;
   wpi::raw_fd_istream input{path, ec};
 
@@ -38,9 +39,14 @@ std::string sysid::ConvertJSON(wpi::StringRef path, wpi::Logger& logger) {
     throw std::runtime_error("Unable to read: " + path.str());
   }
 
-  wpi::json ojson;
-  input >> ojson;
+  wpi::json json;
+  input >> json;
   WPI_INFO(logger, "Read frc-characterization JSON from " << path);
+  return json;
+}
+
+std::string sysid::ConvertJSON(wpi::StringRef path, wpi::Logger& logger) {
+  wpi::json ojson = GetJSON(path, logger);
 
   auto type = sysid::analysis::FromName(ojson.at("test").get<std::string>());
   auto factor = ojson.at("unitsPerRotation").get<double>();
@@ -84,10 +90,75 @@ std::string sysid::ConvertJSON(wpi::StringRef path, wpi::Logger& logger) {
 
   // Write the new file with "_new" appended to it.
   std::string loc = path.rsplit(".json").first.str() + "_new.json";
+  std::error_code ec;
   wpi::raw_fd_ostream output{loc, ec};
   output << json;
   output.flush();
 
   WPI_INFO(logger, "Wrote new JSON to: " << loc);
+  return loc;
+}
+
+std::string sysid::ToCSV(wpi::StringRef path, wpi::Logger& logger) {
+  wpi::json json = GetJSON(path, logger);
+
+  auto type = sysid::analysis::FromName(json.at("test").get<std::string>());
+  auto factor = json.at("unitsPerRotation").get<double>();
+  auto unit = json.at("units").get<std::string>();
+  auto abbreviation = GetAbbreviation(unit);
+
+  std::error_code ec;
+  // Naming: {sysid-json-name}(Test, Units).csv
+  std::string loc = path.rsplit(".json").first.str() + "(" + type.name + ", " +
+                    unit + ").csv";
+  wpi::raw_fd_ostream outputFile{loc, ec};
+
+  if (ec) {
+    throw std::runtime_error("Unable to write to: " + loc);
+  }
+
+  outputFile << "Timestamp (s),Test,";
+  if (type == analysis::kDrivetrain || type == analysis::kDrivetrainAngular) {
+    outputFile << "Left Volts (V),Right Volts (V),"
+               << "Left Position (" << abbreviation << "),"
+               << "Right Position(" << abbreviation << "),"
+               << "Left Velocity (" << unit << "/s),"
+               << "Right Velocity (" << unit << "/s),"
+               << "Gyro Position (deg),Gyro Rate (deg/s)";
+
+  } else {
+    outputFile << "Volts (V),Position (" << abbreviation << "),Velocity ("
+               << abbreviation << "/s)";
+  }
+  outputFile << "\n";
+
+  for (auto&& key : AnalysisManager::kJsonDataKeys) {
+    if (type == analysis::kDrivetrain || type == analysis::kDrivetrainAngular) {
+      auto tempData =
+          json.at(key).get<std::vector<std::array<double, kDrivetrainSize>>>();
+      for (auto&& pt : tempData) {
+        outputFile << pt[0] << ", " << key << ", "    // Timestamp, Test
+                   << pt[1] << ", " << pt[2] << ", "  // Left and Right Voltages
+                   << pt[3] * factor << ", " << pt[4] * factor
+                   << ", "  // Left and Right Positions
+                   << pt[5] * factor << ", " << pt[6] * factor
+                   << ", "                    // Left and Right Velocities
+                   << pt[7] << ", " << pt[8]  // Gyro Position and Velocity
+                   << "\n";
+      }
+    } else {
+      auto tempData =
+          json.at(key).get<std::vector<std::array<double, kGeneralSize>>>();
+      for (auto&& pt : tempData) {
+        outputFile << pt[0] << ", " << key << ", "  // Timestamp, Test
+                   << pt[1] << ", "                 // Voltage
+                   << pt[2] * factor << ", "        // Position
+                   << pt[3] * factor                // Velocity
+                   << "\n";
+      }
+    }
+  }
+  outputFile.flush();
+  WPI_INFO(logger, "Wrote CSV to: " << loc);
   return loc;
 }

--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -562,7 +562,8 @@ void Analyzer::PrepareGraphs() {
     AbortDataPrep();
     m_dataThread = std::thread([&] {
       m_plot.SetData(m_manager->GetRawData(), m_manager->GetFilteredData(),
-                     m_ff, m_manager->GetStartTimes(), m_type, m_abortDataPrep);
+                     m_manager->GetUnit(), m_ff, m_manager->GetStartTimes(),
+                     m_type, m_abortDataPrep);
     });
   } catch (const std::exception& e) {
     m_exception = e.what();

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -16,6 +16,7 @@
 #include <units/time.h>
 #include <wpi/raw_ostream.h>
 
+#include "sysid/Util.h"
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/AnalysisType.h"
 #include "sysid/analysis/ArmSim.h"
@@ -75,6 +76,7 @@ AnalyzerPlot::AnalyzerPlot(wpi::Logger& logger) : m_logger(logger) {
 }
 
 void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
+                           const std::string& unit,
                            const std::vector<double>& ffGains,
                            const std::array<units::second_t, 4>& startTimes,
                            AnalysisType type, std::atomic<bool>& abort) {
@@ -83,6 +85,10 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
   const auto& Ks = ffGains[0];
   const auto& Kv = ffGains[1];
   const auto& Ka = ffGains[2];
+
+  auto abbreviation = GetAbbreviation(unit);
+  m_velocityLabel = "Velocity (" + abbreviation + " / s)";
+  m_accelerationLabel = "Acceleration (" + abbreviation + " / s^2)";
 
   std::scoped_lock lock(m_mutex);
 
@@ -374,7 +380,7 @@ bool AnalyzerPlot::DisplayTimeDomainPlots(ImVec2 plotSize) {
   for (size_t i = 2; i < 6; ++i) {
     const char* x = "Time (s)";
     const char* y =
-        i % 2 == 0 ? "Velocity (units / s)" : "Acceleration (units / s / s)";
+        i % 2 == 0 ? m_velocityLabel.c_str() : m_accelerationLabel.c_str();
     bool isVelocity = (i == 2 || i == 4);
 
     // Get a reference to the data we are plotting.

--- a/src/main/native/cpp/view/JSONConverter.cpp
+++ b/src/main/native/cpp/view/JSONConverter.cpp
@@ -15,18 +15,19 @@
 
 using namespace sysid;
 
-void JSONConverter::Display() {
-  if (ImGui::Button("Select frc-characterization JSON")) {
+void JSONConverter::DisplayConverter(
+    const char* tooltip,
+    std::function<std::string(wpi::StringRef, wpi::Logger&)> converter) {
+  if (ImGui::Button(tooltip)) {
     m_opener = std::make_unique<pfd::open_file>(
-        "Select frc-characterization JSON", "",
-        std::vector<std::string>{"JSON File", SYSID_PFD_JSON_EXT});
+        tooltip, "", std::vector<std::string>{"JSON File", SYSID_PFD_JSON_EXT});
   }
 
   if (m_opener && m_opener->ready()) {
     if (!m_opener->result().empty()) {
       m_location = m_opener->result()[0];
       try {
-        sysid::ConvertJSON(m_location, m_logger);
+        converter(m_location, m_logger);
         m_timestamp = wpi::Now() * 1E-6;
       } catch (const std::exception& e) {
         ImGui::OpenPopup("Exception Caught!");
@@ -53,4 +54,12 @@ void JSONConverter::Display() {
     }
     ImGui::EndPopup();
   }
+}
+
+void JSONConverter::DisplayFRCCharConvert() {
+  DisplayConverter("Select FRC-Char JSON", sysid::ConvertJSON);
+}
+
+void JSONConverter::DisplayCSVConvert() {
+  DisplayConverter("Select SysId JSON", sysid::ToCSV);
 }

--- a/src/main/native/include/sysid/Util.h
+++ b/src/main/native/include/sysid/Util.h
@@ -25,4 +25,5 @@
 namespace sysid {
 void CreateTooltip(const char* text);
 std::vector<std::string> Split(const std::string& s, char c);
+std::string GetAbbreviation(std::string unit);
 }  // namespace sysid

--- a/src/main/native/include/sysid/Util.h
+++ b/src/main/native/include/sysid/Util.h
@@ -25,5 +25,5 @@
 namespace sysid {
 void CreateTooltip(const char* text);
 std::vector<std::string> Split(const std::string& s, char c);
-std::string GetAbbreviation(std::string unit);
+std::string GetAbbreviation(const std::string& unit);
 }  // namespace sysid

--- a/src/main/native/include/sysid/analysis/JSONConverter.h
+++ b/src/main/native/include/sysid/analysis/JSONConverter.h
@@ -20,4 +20,6 @@ namespace sysid {
  * @return The full file path of the newly saved JSON.
  */
 std::string ConvertJSON(wpi::StringRef path, wpi::Logger& logger);
+
+std::string ToCSV(wpi::StringRef path, wpi::Logger& logger);
 }  // namespace sysid

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <atomic>
+#include <string>
 #include <vector>
 
 #include <imgui.h>
@@ -58,7 +59,7 @@ class AnalyzerPlot {
    *                     thread.
    */
   void SetData(const Storage& rawData, const Storage& filteredData,
-               const std::vector<double>& ff,
+               const std::string& unit, const std::vector<double>& ff,
                const std::array<units::second_t, 4>& startTimes,
                AnalysisType type, std::atomic<bool>& abort);
 
@@ -89,6 +90,9 @@ class AnalyzerPlot {
   // Stores ImPlotPoint vectors for all of the data.
   wpi::StringMap<std::vector<ImPlotPoint>> m_filteredData;
   wpi::StringMap<std::vector<ImPlotPoint>> m_rawData;
+
+  std::string m_velocityLabel;
+  std::string m_accelerationLabel;
 
   // Stores points for the lines of best fit.
   ImPlotPoint m_KvFit[2];

--- a/src/main/native/include/sysid/view/JSONConverter.h
+++ b/src/main/native/include/sysid/view/JSONConverter.h
@@ -4,20 +4,27 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 
 #include <glass/View.h>
 #include <portable-file-dialogs.h>
 #include <wpi/Logger.h>
+#include <wpi/StringRef.h>
 
 namespace sysid {
 class JSONConverter {
  public:
   explicit JSONConverter(wpi::Logger& logger) : m_logger(logger) {}
-  void Display();
+  void DisplayFRCCharConvert();
+  void DisplayCSVConvert();
 
  private:
+  void DisplayConverter(
+      const char* tooltip,
+      std::function<std::string(wpi::StringRef, wpi::Logger&)>);
+
   wpi::Logger& m_logger;
 
   std::string m_location;


### PR DESCRIPTION
Fixes #91 
Allows users to select a SysId JSON and have it be converted into a CSV file. This lets users better look at individual values and facilitates looking at the data in other programs / languages.

CSV files are saved with the following convention: `sysid-json-name(Test, Units).csv`
e.g:
[sysid_data20210320-0128(Simple, Meters).zip](https://github.com/wpilibsuite/sysid/files/6315595/sysid_data20210320-0128.Simple.Meters.zip)

