### PR TITLE
Add RMSE metric to assess feedforward accuracy

### DIFF
--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -199,6 +199,11 @@ void Analyzer::Display() {
       }
 
       ShowGain("r-squared", &m_rSquared);
+      ShowGain("Sim RMSE", m_plot.GetRMSE());
+      CreateTooltip(
+          "The Root Mean Squared Error (RMSE) of the simulation "
+          "predictions compared to the recorded data. It is essentially the "
+          "error of the simulated model in the recorded units.");
 
       double endY = ImGui::GetCursorPosY();
 

--- a/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -83,6 +83,8 @@ class AnalyzerPlot {
 
   void FitPlots();
 
+  double* GetRMSE() { return &m_RMSE; }
+
  private:
   // The maximum size of each vector (dataset to plot).
   static constexpr size_t kMaxSize = 2048;
@@ -101,6 +103,8 @@ class AnalyzerPlot {
   // Stores points for simulated time-domain data.
   std::vector<std::vector<ImPlotPoint>> m_quasistaticSim;
   std::vector<std::vector<ImPlotPoint>> m_dynamicSim;
+
+  double m_RMSE;
 
   // Stores differences in time deltas
   std::vector<std::vector<ImPlotPoint>> m_dt;


### PR DESCRIPTION
Shows the Root Mean Squared Error of the Simulation Predictions vs Raw Data. Serves as a quantitative way of assessing SysId performance.
![image](https://user-images.githubusercontent.com/29788153/115102567-4a9d1100-9f11-11eb-81aa-3118b714bcd5.png)
