### PR TITLE
Add feedforward data to combined diagnostic plots

### DIFF
--- a/src/main/native/include/sysid/view/Analyzer.h
+++ b/src/main/native/include/sysid/view/Analyzer.h
@@ -51,6 +51,7 @@ class Analyzer : public glass::View {
   void PrepareGraphs();
   void RefreshInformation();
   void AbortDataPrep();
+  void DisplayFeedforwardGains(bool combined = false);
 
   /**
    * Loads the diagnostic plots.


### PR DESCRIPTION
Mainly allows users to also screenshot their settings + gains whenever sharing graphs.
Fixes #107 
![image](https://user-images.githubusercontent.com/29788153/115440042-eca05000-a1d4-11eb-93c7-8212db7ba179.png)
