### PR TITLE
Require pressing enter for window size and velocity threshold

### DIFF
--- a/src/main/native/cpp/view/Analyzer.cpp
+++ b/src/main/native/cpp/view/Analyzer.cpp
@@ -579,24 +579,34 @@ void Analyzer::DisplayFeedforwardGains(bool combined) {
     SetPosition(beginX, beginY, 1, 1);
   }
 
+  // Wait for enter before refresh so double digit entries like "15" don't
+  // prematurely refresh with "1". That can cause display stuttering.
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
   int window = m_settings.windowSize;
-  if (ImGui::InputInt(
-          "Window Size", &window, 0, 0,
-          combined ? ImGuiInputTextFlags_ReadOnly : ImGuiInputTextFlags_None)) {
+  if (ImGui::InputInt("Window Size", &window, 0, 0,
+                      combined ? ImGuiInputTextFlags_ReadOnly
+                               : ImGuiInputTextFlags_EnterReturnsTrue)) {
     m_settings.windowSize = std::clamp(window, 2, 15);
     RefreshInformation();
   }
 
+  CreateTooltip(
+      "The number of samples in the velocity median "
+      "filter's sliding window.");
+
+  // Wait for enter before refresh so decimal inputs like "0.2" don't
+  // prematurely refresh with a velocity threshold of "0".
   SetPosition(beginX, beginY, 1, combined ? 1 : 2);
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
   double threshold = m_settings.motionThreshold;
-  if (ImGui::InputDouble(
-          "Velocity Threshold", &threshold, 0.0, 0.0, "%.3f",
-          combined ? ImGuiInputTextFlags_ReadOnly : ImGuiInputTextFlags_None)) {
+  if (ImGui::InputDouble("Velocity Threshold", &threshold, 0.0, 0.0, "%.3f",
+                         combined ? ImGuiInputTextFlags_ReadOnly
+                                  : ImGuiInputTextFlags_EnterReturnsTrue)) {
     m_settings.motionThreshold = std::max(0.0, threshold);
     RefreshInformation();
   }
+
+  CreateTooltip("Velocity data below this threshold will be ignored.");
 
   SetPosition(beginX, beginY, 1, combined ? 2 : 3);
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);


### PR DESCRIPTION
Also add explanatory tooltips for both.

Closes #117.