### PR TITLE
Convert Raw Data to Prepared Data after reading it

### DIFF
--- a/src/integrationtest_analysis/native/cpp/AnalysisTest.cpp
+++ b/src/integrationtest_analysis/native/cpp/AnalysisTest.cpp
@@ -97,7 +97,7 @@ class AnalysisTest : public ::testing::Test {
     auto path = m_manager->SaveJSON(EXPAND_STRINGIZE(PROJECT_ROOT_DIR));
     try {
       auto analyzerSettings = sysid::AnalysisManager::Settings{};
-      analyzerSettings.windowSize = 15;
+      analyzerSettings.windowSize = 13;
       if (m_settings.mechanism == sysid::analysis::kArm) {
         analyzerSettings.motionThreshold = 0.01;  // Reduce threshold for arm
                                                   // test

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -33,49 +33,6 @@
 using namespace sysid;
 
 /**
- * Helper method that applies a function onto a dataset.
- *
- * @tparam T The type of data that is stored within a StringMap
- *
- * @param data   A StringMap representing a specific dataset
- * @param action A void function that takes a StringRef representing a StringMap
- *               key and performs an action to the dataset stored with that
- *               passed key (e.g. applying a median filter)
- */
-template <typename T>
-void ApplyToData(const wpi::StringMap<T>& data,
-                 std::function<void(wpi::StringRef)> action) {
-  for (const auto& it : data) {
-    action(it.first());
-  }
-}
-
-/**
- * Helper method that applies a function onto a dataset.
- *
- * @tparam T The type of data that is stored within a StringMap
- *
- * @param data      A StringMap representing a specific dataset
- * @param action    A void function that takes a StringRef representing a
- *                  StringMap key and performs an action to the dataset stored
- *                  with that passed key (e.g. applying a median filter)
- * @param specifier A boolean function that takes a StringRef representing a
- *                  StringMap key and returns true if `action` should be run on
- *                  the dataset stored with that key
- */
-template <typename T>
-void ApplyToData(const wpi::StringMap<T>& data,
-                 std::function<void(wpi::StringRef)> action,
-                 std::function<bool(wpi::StringRef)> specifier) {
-  for (const auto& it : data) {
-    auto key = it.first();
-    if (specifier(key)) {
-      action(key);
-    }
-  }
-}
-
-/**
  * Converts a raw data vector into a PreparedData vector with only the
  * timestamp, voltage, position, and velocity fields filled out.
  *
@@ -130,190 +87,6 @@ static std::vector<PreparedData> Concatenate(
 }
 
 /**
- * Fills in the rest of the PreparedData Structs for a PreparedData Vector.
- *
- * @param data   A reference to a vector of the raw data.
- * @param window The window across which to compute the acceleration.
- * @param unit   The units that the data is in (rotations, radians, or degrees)
- * for arm mechanisms.
- */
-void PrepareMechData(std::vector<PreparedData>* data, int window,
-                     wpi::StringRef unit = "") {
-  // Calculate the step size for acceleration data.
-  size_t step = window / 2;
-
-  if (data->size() <= static_cast<size_t>(window)) {
-    throw std::runtime_error(
-        "The data collected is too small! This can be caused by too high of a "
-        "motion threshold or bad data collection.");
-  }
-
-  // Compute acceleration and add it to the vector.
-  for (size_t i = step; i < data->size() - step; ++i) {
-    auto& pt1 = data->at(i);
-    const auto& pt2 = data->at(i + 1);
-
-    double accel = (data->at(i + step).velocity - data->at(i - step).velocity) /
-                   (data->at(i + step).timestamp - data->at(i - step).timestamp)
-                       .to<double>();
-
-    pt1.acceleration = accel;
-
-    // Calculates the cosine of the position data for single jointed arm
-    // analysis
-    double cos = 0.0;
-    if (unit == "Radians") {
-      cos = std::cos(pt1.position);
-    } else if (unit == "Degrees") {
-      cos = std::cos(pt1.position * wpi::math::pi / 180.0);
-    } else if (unit == "Rotations") {
-      cos = std::cos(pt1.position * 2 * wpi::math::pi);
-    }
-    pt1.cos = cos;
-  }
-}
-
-/**
- * Trims data with dt too far from mean.
- *
- * @param data      The data to filter.
- * @param dtMean    The mean dt.
- * @param tolerance The tolerance outside of which to trim.
- */
-static void TrimByTimeDelta(std::vector<PreparedData>* data,
-                            units::second_t dtMean, units::second_t tolerance) {
-  data->erase(std::remove_if(data->begin(), data->end(),
-                             [dtMean, tolerance](const auto& pt) {
-                               return units::math::abs(pt.dt - dtMean) >
-                                      tolerance;
-                             }),
-              data->end());
-}
-
-/**
- * Figures out the max duration of the Dynamic tests
- *
- * @tparam S The size of the arrays in the raw data vector
- *
- * @param data The raw data String Map
- * @param timeCol The index of the time column
- *
- * @return The maximum duration of the Dynamic Tests
- */
-static units::second_t GetMaxTime(
-    wpi::StringMap<std::vector<PreparedData>>& data) {
-  std::vector<double> durations;
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        durations.push_back(
-            (data[key].back().timestamp - data[key].front().timestamp)
-                .to<double>());
-      },
-      [](wpi::StringRef key) {
-        return key.contains("fast") && key.contains("raw");
-      });
-  return units::second_t{durations[std::distance(
-      durations.begin(),
-      std::max_element(durations.begin(), durations.end()))]};
-}
-
-/**
- * Trims the quasistatic tests, applies a median filter to the velocity data,
- * calculates acceleration and cosine (arm only) data, and trims the dynamic
- * tests.
- *
- * @param data A pointer to a data vector recently created by the
- *             ConvertToPrepared method
- * @param settings A reference to the analysis settings
- * @param minStepTime A reference to the minimum dynamic test duration
- * @param maxStepTime A reference to the maximum dynamic test duration
- * @param unit The angular unit that the arm test is in (only for calculating
- *             cosine data)
- */
-static void InitialTrimAndFilter(
-    wpi::StringMap<std::vector<PreparedData>>* data,
-    AnalysisManager::Settings& settings, units::second_t& minStepTime,
-    units::second_t& maxStepTime, wpi::StringRef unit = "") {
-  auto& preparedData = *data;
-
-  // Trim quasistatic test data to remove all points where voltage is zero or
-  // velocity < motion threshold.
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        sysid::TrimQuasistaticData(&preparedData[key],
-                                   settings.motionThreshold);
-      },
-      [](wpi::StringRef key) { return key.contains("slow"); });
-
-  // Apply Median filter
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        sysid::ApplyMedianFilter(&preparedData[key], settings.windowSize);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
-
-  // Recalculate Accel and Cosine
-  ApplyToData(preparedData, [&](wpi::StringRef key) {
-    PrepareMechData(&preparedData[key], settings.windowSize, unit);
-  });
-
-  // Find the maximum Step Test Duration
-  maxStepTime = GetMaxTime(preparedData);
-
-  // Trims all Dynamic Test Data but excludes raw data from calculation of
-  // minimum step time
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        auto tempMinStepTime = sysid::TrimStepVoltageData(
-            &preparedData[key], &settings, minStepTime, maxStepTime);
-        if (!key.startswith("raw")) {
-          minStepTime = tempMinStepTime;
-        }
-      },
-      [](wpi::StringRef key) { return key.contains("fast"); });
-  // Confirm there's still data
-  if (std::any_of(preparedData.begin(), preparedData.end(),
-                  [](const auto& it) { return it.first().empty(); })) {
-    throw std::runtime_error("Trimming removed all data");
-  }
-}
-
-/**
- * Removes all points with accel = 0 and points with dt's greater than 1ms from
- * the mean dt.
- *
- * @param data A pointer to a PreparedData vector
- * @param tempCombined A reference to the combined filtered datasets
- */
-static void AccelAndTimeFilter(wpi::StringMap<std::vector<PreparedData>>* data,
-                               const Storage& tempCombined) {
-  auto& preparedData = *data;
-  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
-
-  // Remove points with dt too far from mean
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
-
-  // Remove points with accel = 0
-  ApplyToData(preparedData,
-              [&](wpi::StringRef key) { FilterAccelData(&preparedData[key]); });
-
-  // Confirm there's still data
-  if (std::any_of(preparedData.begin(), preparedData.end(),
-                  [](const auto& it) { return it.first().empty(); })) {
-    throw std::runtime_error("Trimming removed all data");
-  }
-}
-
-/**
  * Prepares data for general mechanisms (i.e. not drivetrain) and stores them
  * in the analysis manager dataset.
  *
@@ -360,19 +133,20 @@ static void PrepareGeneralData(const wpi::json& json,
   }
 
   // Loads the Raw Data
-  ApplyToData(data, [&](wpi::StringRef key) {
+  sysid::ApplyToData(data, [&](wpi::StringRef key) {
     std::string rawName{"raw-" + key.str()};
     data[rawName] = std::vector<Data>(data[key]);
   });
 
   // Convert data to PreparedData structs
-  ApplyToData(data, [&](wpi::StringRef key) {
+  sysid::ApplyToData(data, [&](wpi::StringRef key) {
     preparedData[key] =
         ConvertToPrepared<4, kTimeCol, kVoltageCol, kPosCol, kVelCol>(
             data[key]);
   });
 
-  InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime, unit);
+  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime,
+                              unit);
   // Compute mean dt
   auto& slowForward = preparedData["slow-forward"];
   auto& slowBackward = preparedData["slow-backward"];
@@ -381,7 +155,7 @@ static void PrepareGeneralData(const wpi::json& json,
   Storage tempCombined{Concatenate(slowForward, {&slowBackward}),
                        Concatenate(fastForward, {&fastBackward})};
 
-  AccelAndTimeFilter(&preparedData, tempCombined);
+  sysid::AccelAndTimeFilter(&preparedData, tempCombined);
 
   // Store the raw datasets
   rawDatasets["Forward"] = Storage{preparedData["raw-slow-forward"],
@@ -455,34 +229,14 @@ static void PrepareAngularDrivetrainData(
   }
 
   // Convert raw data to prepared data
-  ApplyToData(data, [&](wpi::StringRef key) {
+  sysid::ApplyToData(data, [&](wpi::StringRef key) {
     preparedData[key] =
         ConvertToPrepared<9, kTimeCol, kVoltageCol, kAngleCol, kAngularRateCol>(
             data[key]);
   });
 
-  // Trim quasistatic test data to remove all points where voltage is zero or
-  // velocity < motion threshold.
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        sysid::TrimQuasistaticData(&preparedData[key],
-                                   settings.motionThreshold);
-      },
-      [](wpi::StringRef key) { return key.contains("slow"); });
-
-  // Get Max Time
-  maxStepTime = GetMaxTime(preparedData);
-
-  // Trim the step voltage data.
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        minStepTime = sysid::TrimStepVoltageData(&preparedData[key], &settings,
-                                                 minStepTime, maxStepTime);
-      },
-      [](wpi::StringRef key) { return key.contains("fast"); });
-
+  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime,
+                              maxStepTime);
   // Compute mean dt
   auto& slowForward = preparedData["slow-forward"];
   auto& slowBackward = preparedData["slow-backward"];
@@ -490,21 +244,8 @@ static void PrepareAngularDrivetrainData(
   auto& fastBackward = preparedData["fast-backward"];
   Storage tempCombined{Concatenate(slowForward, {&slowBackward}),
                        Concatenate(fastForward, {&fastBackward})};
-  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
 
-  // Remove points with dt too far from mean
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
-
-  // Confirm there's still data
-  if (std::all_of(preparedData.begin(), preparedData.end(),
-                  [](const auto& it) { return it.first().empty(); })) {
-    throw std::runtime_error("Trimming removed all data");
-  }
+  sysid::AccelAndTimeFilter(&preparedData, tempCombined);
 
   // Calculate track width from the slow-forward raw data.
   auto& trackWidthData = data["slow-forward"];
@@ -578,13 +319,13 @@ static void PrepareLinearDrivetrainData(
   }
 
   // Load Raw Data
-  ApplyToData(data, [&](wpi::StringRef key) {
+  sysid::ApplyToData(data, [&](wpi::StringRef key) {
     std::string rawName{"raw-" + key.str()};
     data[rawName] = std::vector<Data>(data[key]);
   });
 
   // Convert data to PreparedData
-  ApplyToData(data, [&](wpi::StringRef key) {
+  sysid::ApplyToData(data, [&](wpi::StringRef key) {
     std::string leftName{"left-" + key.str()};
     std::string rightName{"right-" + key.str()};
     preparedData[leftName] =
@@ -595,7 +336,8 @@ static void PrepareLinearDrivetrainData(
             data[key]);
   });
 
-  InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime);
+  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime,
+                              maxStepTime);
   // Store filtered data
   auto& slowForwardLeft = preparedData["left-slow-forward"];
   auto& slowForwardRight = preparedData["right-slow-forward"];
@@ -615,7 +357,7 @@ static void PrepareLinearDrivetrainData(
   Storage tempCombined{Concatenate(slowForward, {&slowBackward}),
                        Concatenate(fastForward, {&fastBackward})};
 
-  AccelAndTimeFilter(&preparedData, tempCombined);
+  sysid::AccelAndTimeFilter(&preparedData, tempCombined);
 
   // Store raw data as variables
   auto rawSlowForwardLeft = preparedData["left-raw-slow-forward"];

--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -14,6 +14,7 @@
 #include <limits>
 #include <stdexcept>
 #include <system_error>
+#include <vector>
 
 #include <units/angle.h>
 #include <units/math.h>
@@ -75,8 +76,40 @@ void ApplyToData(const wpi::StringMap<T>& data,
 }
 
 /**
+ * Converts a raw data vector into a PreparedData vector with only the
+ * timestamp, voltage, position, and velocity fields filled out.
+ *
+ * @tparam S The size of the arrays in the raw data vector
+ * @tparam Timestamp The index of the Timestamp data in the raw data vector
+ * arrays
+ * @tparam Voltage The index of the Voltage data in the raw data vector arrays
+ * @tparam Position The index of the Position data in the raw data vector arrays
+ * @tparam Velocity The index of the Velocity data in the raw data vector arrays
+ *
+ * @param data A raw data vector
+ *
+ * @return A PreparedData vector
+ */
+template <size_t S, size_t Timestamp, size_t Voltage, size_t Position,
+          size_t Velocity>
+static std::vector<PreparedData> ConvertToPrepared(
+    const std::vector<std::array<double, S>>& data) {
+  std::vector<PreparedData> prepared;
+  for (int i = 0; i < data.size() - 1; i++) {
+    const auto& pt1 = data[i];
+    const auto& pt2 = data[i + 1];
+    prepared.emplace_back(
+        PreparedData{units::second_t{pt1[Timestamp]}, pt1[Voltage],
+                     pt1[Position], pt1[Velocity], pt2[Velocity],
+                     units::second_t{pt2[Timestamp] - pt1[Timestamp]}});
+  }
+  return prepared;
+}
+
+/**
  * Concatenates a list of vectors to the end of a vector. The contents of the
- * source vectors are copied (not moved) into the new vector.
+ * source vectors are copied (not moved) into the new vector. Also sorts the
+ * datapoints by timestamp to assist with future simulation.
  */
 static std::vector<PreparedData> Concatenate(
     std::vector<PreparedData> dest,
@@ -86,114 +119,58 @@ static std::vector<PreparedData> Concatenate(
     dest.insert(dest.end(), ptr->cbegin(), ptr->cend());
   }
 
+  // Sort data by timestamp to remove the possibility of negative dts in future
+  // simulations.
+  std::sort(dest.begin(), dest.end(), [](const auto& a, const auto& b) {
+    return a.timestamp < b.timestamp;
+  });
+
   // Return the dest vector.
   return dest;
 }
 
 /**
- * Generates general prepared data from a vector of raw data.
- *
- * @tparam S        The size of the raw data array.
- * @tparam Voltage  The index of the voltage entry in the raw data.
- * @tparam Position The index of the position entry in the raw data.
- * @tparam Velocity The index of the velocity entry in the raw data.
+ * Fills in the rest of the PreparedData Structs for a PreparedData Vector.
  *
  * @param data   A reference to a vector of the raw data.
  * @param window The window across which to compute the acceleration.
- * @param unit   The units that the data is in (rotations, radians, or degrees).
+ * @param unit   The units that the data is in (rotations, radians, or degrees)
+ * for arm mechanisms.
  */
-template <size_t S, size_t Voltage, size_t Position, size_t Velocity>
-std::vector<PreparedData> PrepareGeneralData(
-    const std::vector<std::array<double, S>>& data, int window,
-    wpi::StringRef unit) {
+void PrepareMechData(std::vector<PreparedData>* data, int window,
+                     wpi::StringRef unit = "") {
   // Calculate the step size for acceleration data.
   size_t step = window / 2;
 
-  // Create our prepared data vector.
-  std::vector<PreparedData> prepared;
-  if (data.size() <= static_cast<size_t>(window)) {
+  if (data->size() <= static_cast<size_t>(window)) {
     throw std::runtime_error(
         "The data collected is too small! This can be caused by too high of a "
         "motion threshold or bad data collection.");
   }
-  prepared.reserve(data.size());
 
   // Compute acceleration and add it to the vector.
-  for (size_t i = step; i < data.size() - step; ++i) {
-    const auto& pt1 = data[i];
-    const auto& pt2 = data[i + 1];
+  for (size_t i = step; i < data->size() - step; ++i) {
+    auto& pt1 = data->at(i);
+    const auto& pt2 = data->at(i + 1);
 
-    double accel = (data[i + step][Velocity] - data[i - step][Velocity]) /
-                   (data[i + step][0] - data[i - step][0]);
-    // Sometimes, if the encoder velocities are the same, it will register zero
-    // acceleration. Do not include these values.
-    if (accel == 0.0) {
-      continue;
-    }
+    double accel = (data->at(i + step).velocity - data->at(i - step).velocity) /
+                   (data->at(i + step).timestamp - data->at(i - step).timestamp)
+                       .to<double>();
+
+    pt1.acceleration = accel;
 
     // Calculates the cosine of the position data for single jointed arm
     // analysis
-    double cos;
+    double cos = 0.0;
     if (unit == "Radians") {
-      cos = std::cos(pt1[Position]);
+      cos = std::cos(pt1.position);
     } else if (unit == "Degrees") {
-      cos = std::cos(pt1[Position] * wpi::math::pi / 180.0);
+      cos = std::cos(pt1.position * wpi::math::pi / 180.0);
     } else if (unit == "Rotations") {
-      cos = std::cos(pt1[Position] * 2 * wpi::math::pi);
+      cos = std::cos(pt1.position * 2 * wpi::math::pi);
     }
-
-    prepared.push_back(PreparedData{
-        units::second_t{pt1[0]}, pt1[Voltage], pt1[Position], pt1[Velocity],
-        pt2[Velocity], units::second_t{pt2[0] - pt1[0]}, accel, cos});
+    pt1.cos = cos;
   }
-  return prepared;
-}
-
-/**
- * Generates general prepared data from a vector of raw data.
- *
- * @tparam S        The size of the raw data array.
- * @tparam Voltage  The index of the voltage entry in the raw data.
- * @tparam Position The index of the position entry in the raw data.
- * @tparam Velocity The index of the velocity entry in the raw data.
- *
- * @param data   A reference to a vector of the raw data.
- * @param window The window across which to compute the acceleration.
- * @param unit   The units that the data is in (rotations, radians, or degrees).
- */
-template <size_t S, size_t Voltage, size_t Position, size_t Velocity>
-std::vector<PreparedData> PrepareDrivetrainData(
-    const std::vector<std::array<double, S>>& data, int window) {
-  // Calculate the step size for acceleration data.
-  size_t step = window / 2;
-
-  // Create our prepared data vector.
-  std::vector<PreparedData> prepared;
-  if (data.size() <= static_cast<size_t>(window)) {
-    throw std::runtime_error(
-        "The data collected is too small! This can be caused by too high of a "
-        "motion threshold or bad data collection.");
-  }
-  prepared.reserve(data.size());
-
-  // Compute acceleration and add it to the vector.
-  for (size_t i = step; i < data.size() - step; ++i) {
-    const auto& pt1 = data[i];
-    const auto& pt2 = data[i + 1];
-
-    double accel = (data[i + step][Velocity] - data[i - step][Velocity]) /
-                   (data[i + step][0] - data[i - step][0]);
-    // Sometimes, if the encoder velocities are the same, it will register zero
-    // acceleration. Do not include these values.
-    if (accel == 0.0) {
-      continue;
-    }
-
-    prepared.push_back(PreparedData{
-        units::second_t{pt1[0]}, pt1[Voltage], pt1[Position], pt1[Velocity],
-        pt2[Velocity], units::second_t{pt2[0] - pt1[0]}, accel, 0.0});
-  }
-  return prepared;
 }
 
 /**
@@ -213,13 +190,127 @@ static void TrimByTimeDelta(std::vector<PreparedData>* data,
               data->end());
 }
 
-template <size_t S>
+/**
+ * Figures out the max duration of the Dynamic tests
+ *
+ * @tparam S The size of the arrays in the raw data vector
+ *
+ * @param data The raw data String Map
+ * @param timeCol The index of the time column
+ *
+ * @return The maximum duration of the Dynamic Tests
+ */
 static units::second_t GetMaxTime(
-    wpi::StringMap<std::vector<std::array<double, S>>>& data, size_t timeCol) {
-  return units::second_t{std::max(
-      data["fast-forward"].back()[timeCol] - data["fast-forward"][0][timeCol],
-      data["fast-backward"].back()[timeCol] -
-          data["fast-backward"][0][timeCol])};
+    wpi::StringMap<std::vector<PreparedData>>& data) {
+  std::vector<double> durations;
+  ApplyToData(
+      data,
+      [&](wpi::StringRef key) {
+        durations.push_back(
+            (data[key].back().timestamp - data[key].front().timestamp)
+                .to<double>());
+      },
+      [](wpi::StringRef key) {
+        return key.contains("fast") && key.contains("raw");
+      });
+  return units::second_t{durations[std::distance(
+      durations.begin(),
+      std::max_element(durations.begin(), durations.end()))]};
+}
+
+/**
+ * Trims the quasistatic tests, applies a median filter to the velocity data,
+ * calculates acceleration and cosine (arm only) data, and trims the dynamic
+ * tests.
+ *
+ * @param data A pointer to a data vector recently created by the
+ *             ConvertToPrepared method
+ * @param settings A reference to the analysis settings
+ * @param minStepTime A reference to the minimum dynamic test duration
+ * @param maxStepTime A reference to the maximum dynamic test duration
+ * @param unit The angular unit that the arm test is in (only for calculating
+ *             cosine data)
+ */
+static void InitialTrimAndFilter(
+    wpi::StringMap<std::vector<PreparedData>>* data,
+    AnalysisManager::Settings& settings, units::second_t& minStepTime,
+    units::second_t& maxStepTime, wpi::StringRef unit = "") {
+  auto& preparedData = *data;
+
+  // Trim quasistatic test data to remove all points where voltage is zero or
+  // velocity < motion threshold.
+  ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        sysid::TrimQuasistaticData(&preparedData[key],
+                                   settings.motionThreshold);
+      },
+      [](wpi::StringRef key) { return key.contains("slow"); });
+
+  // Apply Median filter
+  ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        sysid::ApplyMedianFilter(&preparedData[key], settings.windowSize);
+      },
+      [](wpi::StringRef key) { return !key.startswith("raw"); });
+
+  // Recalculate Accel and Cosine
+  ApplyToData(preparedData, [&](wpi::StringRef key) {
+    PrepareMechData(&preparedData[key], settings.windowSize, unit);
+  });
+
+  // Find the maximum Step Test Duration
+  maxStepTime = GetMaxTime(preparedData);
+
+  // Trims all Dynamic Test Data but excludes raw data from calculation of
+  // minimum step time
+  ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        auto tempMinStepTime = sysid::TrimStepVoltageData(
+            &preparedData[key], &settings, minStepTime, maxStepTime);
+        if (!key.startswith("raw")) {
+          minStepTime = tempMinStepTime;
+        }
+      },
+      [](wpi::StringRef key) { return key.contains("fast"); });
+  // Confirm there's still data
+  if (std::any_of(preparedData.begin(), preparedData.end(),
+                  [](const auto& it) { return it.first().empty(); })) {
+    throw std::runtime_error("Trimming removed all data");
+  }
+}
+
+/**
+ * Removes all points with accel = 0 and points with dt's greater than 1ms from
+ * the mean dt.
+ *
+ * @param data A pointer to a PreparedData vector
+ * @param tempCombined A reference to the combined filtered datasets
+ */
+static void AccelAndTimeFilter(wpi::StringMap<std::vector<PreparedData>>* data,
+                               const Storage& tempCombined) {
+  auto& preparedData = *data;
+  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
+
+  // Remove points with dt too far from mean
+  ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
+      },
+      [](wpi::StringRef key) { return !key.startswith("raw"); });
+
+  // Remove points with accel = 0
+  ApplyToData(preparedData,
+              [&](wpi::StringRef key) { FilterAccelData(&preparedData[key]); });
+
+  // Confirm there's still data
+  if (std::any_of(preparedData.begin(), preparedData.end(),
+                  [](const auto& it) { return it.first().empty(); })) {
+    throw std::runtime_error("Trimming removed all data");
+  }
 }
 
 /**
@@ -274,46 +365,14 @@ static void PrepareGeneralData(const wpi::json& json,
     data[rawName] = std::vector<Data>(data[key]);
   });
 
-  // Trim quasistatic test data to remove all points where voltage is zero or
-  // velocity < motion threshold.
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        sysid::TrimQuasistaticData<4, kVoltageCol, kVelCol>(
-            &data[key], settings.motionThreshold);
-      },
-      [](wpi::StringRef key) { return key.contains("slow"); });
-
-  // Convert raw data to prepared data
+  // Convert data to PreparedData structs
   ApplyToData(data, [&](wpi::StringRef key) {
-    preparedData[key] = PrepareGeneralData<4, kVoltageCol, kPosCol, kVelCol>(
-        data[key], settings.windowSize, unit);
+    preparedData[key] =
+        ConvertToPrepared<4, kTimeCol, kVoltageCol, kPosCol, kVelCol>(
+            data[key]);
   });
 
-  // Apply Median filter
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        sysid::ApplyMedianFilter<4, kVelCol>(&data[key], settings.windowSize);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
-
-  // Find the maximum Step Test Duration
-  maxStepTime = GetMaxTime<4>(data, kTimeCol);
-
-  // Trims all Dynamic Test Data but excludes raw data from calculation of
-  // minimum step time
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        auto tempMinStepTime = sysid::TrimStepVoltageData(
-            &preparedData[key], &settings, minStepTime, maxStepTime);
-        if (!key.startswith("raw")) {
-          minStepTime = tempMinStepTime;
-        }
-      },
-      [](wpi::StringRef key) { return key.contains("fast"); });
-
+  InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime, unit);
   // Compute mean dt
   auto& slowForward = preparedData["slow-forward"];
   auto& slowBackward = preparedData["slow-backward"];
@@ -321,15 +380,8 @@ static void PrepareGeneralData(const wpi::json& json,
   auto& fastBackward = preparedData["fast-backward"];
   Storage tempCombined{Concatenate(slowForward, {&slowBackward}),
                        Concatenate(fastForward, {&fastBackward})};
-  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
 
-  // Remove points with dt too far from mean
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
+  AccelAndTimeFilter(&preparedData, tempCombined);
 
   // Store the raw datasets
   rawDatasets["Forward"] = Storage{preparedData["raw-slow-forward"],
@@ -348,8 +400,10 @@ static void PrepareGeneralData(const wpi::json& json,
   filteredDatasets["Combined"] =
       Storage{Concatenate(slowForward, {&slowBackward}),
               Concatenate(fastForward, {&fastBackward})};
-  startTimes = {slowForward[0].timestamp, slowBackward[0].timestamp,
-                fastForward[0].timestamp, fastBackward[0].timestamp};
+  startTimes = {preparedData["raw-slow-forward"][0].timestamp,
+                preparedData["raw-slow-backward"][0].timestamp,
+                preparedData["raw-fast-forward"][0].timestamp,
+                preparedData["raw-fast-backward"][0].timestamp};
 }
 
 /**
@@ -400,25 +454,25 @@ static void PrepareAngularDrivetrainData(
     }
   }
 
-  // Trim quasistatic test data to remove all points where voltage is zero or
-  // velocity < motion threshold.
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        sysid::TrimQuasistaticData<9, kVoltageCol, kAngularRateCol>(
-            &data[key], settings.motionThreshold);
-      },
-      [](wpi::StringRef key) { return key.contains("slow"); });
-
   // Convert raw data to prepared data
   ApplyToData(data, [&](wpi::StringRef key) {
     preparedData[key] =
-        PrepareDrivetrainData<9, kVoltageCol, kAngleCol, kAngularRateCol>(
-            data[key], settings.windowSize);
+        ConvertToPrepared<9, kTimeCol, kVoltageCol, kAngleCol, kAngularRateCol>(
+            data[key]);
   });
 
+  // Trim quasistatic test data to remove all points where voltage is zero or
+  // velocity < motion threshold.
+  ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        sysid::TrimQuasistaticData(&preparedData[key],
+                                   settings.motionThreshold);
+      },
+      [](wpi::StringRef key) { return key.contains("slow"); });
+
   // Get Max Time
-  maxStepTime = GetMaxTime<9>(data, kTimeCol);
+  maxStepTime = GetMaxTime(preparedData);
 
   // Trim the step voltage data.
   ApplyToData(
@@ -529,62 +583,28 @@ static void PrepareLinearDrivetrainData(
     data[rawName] = std::vector<Data>(data[key]);
   });
 
-  // Trim Quasistatic Data
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        sysid::TrimQuasistaticData<9, kLVoltageCol, kLVelCol>(
-            &data[key], settings.motionThreshold);
-        sysid::TrimQuasistaticData<9, kRVoltageCol, kRVelCol>(
-            &data[key], settings.motionThreshold);
-      },
-      [](wpi::StringRef key) { return key.contains("slow"); });
-
-  // Convert raw data to prepared data
+  // Convert data to PreparedData
   ApplyToData(data, [&](wpi::StringRef key) {
     std::string leftName{"left-" + key.str()};
     std::string rightName{"right-" + key.str()};
     preparedData[leftName] =
-        PrepareDrivetrainData<9, kLVoltageCol, kLPosCol, kLVelCol>(
-            data[key], settings.windowSize);
+        ConvertToPrepared<9, kTimeCol, kLVoltageCol, kLPosCol, kLVelCol>(
+            data[key]);
     preparedData[rightName] =
-        PrepareDrivetrainData<9, kRVoltageCol, kRPosCol, kRVelCol>(
-            data[key], settings.windowSize);
+        ConvertToPrepared<9, kTimeCol, kRVoltageCol, kRPosCol, kRVelCol>(
+            data[key]);
   });
 
-  // Apply Median Filter
-  ApplyToData(
-      data,
-      [&](wpi::StringRef key) {
-        sysid::ApplyMedianFilter<9, kLVelCol>(&data[key], settings.windowSize);
-        sysid::ApplyMedianFilter<9, kRVelCol>(&data[key], settings.windowSize);
-      },
-      [](wpi::StringRef key) { return !key.contains("raw"); });
-
-  // Get maximum dynamic test duration
-  maxStepTime = GetMaxTime<9>(data, kTimeCol);
-
-  // Trim step test data but exclude raw data from calculating min step time
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        auto tempMinStepTime = sysid::TrimStepVoltageData(
-            &preparedData[key], &settings, minStepTime, maxStepTime);
-        if (!key.contains("raw")) {
-          minStepTime = tempMinStepTime;
-        }
-      },
-      [](wpi::StringRef key) { return key.contains("fast"); });
-
+  InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime);
   // Store filtered data
-  auto slowForwardLeft = preparedData["left-slow-forward"];
-  auto slowForwardRight = preparedData["right-slow-forward"];
-  auto slowBackwardLeft = preparedData["left-slow-backward"];
-  auto slowBackwardRight = preparedData["right-slow-backward"];
-  auto fastForwardLeft = preparedData["left-fast-forward"];
-  auto fastForwardRight = preparedData["right-fast-forward"];
-  auto fastBackwardLeft = preparedData["left-fast-backward"];
-  auto fastBackwardRight = preparedData["right-fast-backward"];
+  auto& slowForwardLeft = preparedData["left-slow-forward"];
+  auto& slowForwardRight = preparedData["right-slow-forward"];
+  auto& slowBackwardLeft = preparedData["left-slow-backward"];
+  auto& slowBackwardRight = preparedData["right-slow-backward"];
+  auto& fastForwardLeft = preparedData["left-fast-forward"];
+  auto& fastForwardRight = preparedData["right-fast-forward"];
+  auto& fastBackwardLeft = preparedData["left-fast-backward"];
+  auto& fastBackwardRight = preparedData["right-fast-backward"];
 
   auto slowForward = Concatenate(slowForwardLeft, {&slowForwardRight});
   auto slowBackward = Concatenate(slowBackwardLeft, {&slowBackwardRight});
@@ -594,21 +614,8 @@ static void PrepareLinearDrivetrainData(
   // Compute mean dt
   Storage tempCombined{Concatenate(slowForward, {&slowBackward}),
                        Concatenate(fastForward, {&fastBackward})};
-  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
 
-  // Remove points with dt too far from mean
-  ApplyToData(
-      preparedData,
-      [&](wpi::StringRef key) {
-        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
-      },
-      [](wpi::StringRef key) { return !key.startswith("raw"); });
-
-  // Confirm there's still data
-  if (std::all_of(preparedData.begin(), preparedData.end(),
-                  [](const auto& it) { return it.first().empty(); })) {
-    throw std::runtime_error("Trimming removed all data");
-  }
+  AccelAndTimeFilter(&preparedData, tempCombined);
 
   // Store raw data as variables
   auto rawSlowForwardLeft = preparedData["left-raw-slow-forward"];
@@ -668,8 +675,9 @@ static void PrepareLinearDrivetrainData(
   filteredDatasets["Right Combined"] =
       Storage{Concatenate(slowForwardRight, {&slowBackwardRight}),
               Concatenate(fastForwardRight, {&fastBackwardRight})};
-  startTimes = {slowForward.front().timestamp, slowBackward.front().timestamp,
-                fastForward.front().timestamp, fastBackward.front().timestamp};
+  startTimes = {
+      rawSlowForward.front().timestamp, rawSlowBackward.front().timestamp,
+      rawFastForward.front().timestamp, rawFastBackward.front().timestamp};
 }
 
 AnalysisManager::AnalysisManager(wpi::StringRef path, Settings& settings,

--- a/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -9,8 +9,54 @@
 
 #include <frc/LinearFilter.h>
 #include <frc/MedianFilter.h>
+#include <units/math.h>
+#include <wpi/math>
 
 using namespace sysid;
+
+/**
+ * Fills in the rest of the PreparedData Structs for a PreparedData Vector.
+ *
+ * @param data   A reference to a vector of the raw data.
+ * @param window The window across which to compute the acceleration.
+ * @param unit   The units that the data is in (rotations, radians, or degrees)
+ * for arm mechanisms.
+ */
+static void PrepareMechData(std::vector<PreparedData>* data, int window,
+                            wpi::StringRef unit = "") {
+  // Calculate the step size for acceleration data.
+  size_t step = window / 2;
+
+  if (data->size() <= static_cast<size_t>(window)) {
+    throw std::runtime_error(
+        "The data collected is too small! This can be caused by too high of a "
+        "motion threshold or bad data collection.");
+  }
+
+  // Compute acceleration and add it to the vector.
+  for (size_t i = step; i < data->size() - step; ++i) {
+    auto& pt1 = data->at(i);
+    const auto& pt2 = data->at(i + 1);
+
+    double accel = (data->at(i + step).velocity - data->at(i - step).velocity) /
+                   (data->at(i + step).timestamp - data->at(i - step).timestamp)
+                       .to<double>();
+
+    pt1.acceleration = accel;
+
+    // Calculates the cosine of the position data for single jointed arm
+    // analysis
+    double cos = 0.0;
+    if (unit == "Radians") {
+      cos = std::cos(pt1.position);
+    } else if (unit == "Degrees") {
+      cos = std::cos(pt1.position * wpi::math::pi / 180.0);
+    } else if (unit == "Rotations") {
+      cos = std::cos(pt1.position * 2 * wpi::math::pi);
+    }
+    pt1.cos = cos;
+  }
+}
 
 units::second_t sysid::TrimStepVoltageData(std::vector<PreparedData>* data,
                                            AnalysisManager::Settings* settings,
@@ -107,11 +153,10 @@ void sysid::ApplyMedianFilter(std::vector<PreparedData>* data, int window) {
   size_t step = window / 2;
   frc::MedianFilter<double> medianFilter(window);
 
-  // Load the median filter with the first value, step times for accurate
-  // behaviour at the start.
-
+  // Load the median filter with the first value, "step" number of times for
+  // accurate initial behavior.
   for (int i = 0; i < step; i++) {
-    medianFilter.Calculate(data->at(i).velocity);
+    medianFilter.Calculate(data->at(0).velocity);
   }
 
   for (size_t i = 0; i < data->size(); i++) {
@@ -121,7 +166,8 @@ void sysid::ApplyMedianFilter(std::vector<PreparedData>* data, int window) {
     }
   }
 
-  // Run the median filter for the last values and fill it with the last value
+  // Run the median filter for the last "step" datapoints by loading the median
+  // filter with the last recorded velocity value.
   for (int i = data->size() - step; i < data->size(); i++) {
     double median = medianFilter.Calculate(data->at(data->size() - 1).velocity);
     data->at(i).velocity = median;
@@ -134,5 +180,126 @@ void sysid::FilterAccelData(std::vector<PreparedData>* data) {
       data->erase(data->begin() + i);
       i--;
     }
+  }
+}
+
+/**
+ * Figures out the max duration of the Dynamic tests
+ *
+ * @tparam S The size of the arrays in the raw data vector
+ *
+ * @param data The raw data String Map
+ * @param timeCol The index of the time column
+ *
+ * @return The maximum duration of the Dynamic Tests
+ */
+static units::second_t GetMaxTime(
+    wpi::StringMap<std::vector<PreparedData>>& data) {
+  std::vector<double> durations;
+  sysid::ApplyToData(
+      data,
+      [&](wpi::StringRef key) {
+        durations.push_back(
+            (data[key].back().timestamp - data[key].front().timestamp)
+                .to<double>());
+      },
+      [](wpi::StringRef key) {
+        return key.contains("fast") && key.contains("raw");
+      });
+  return units::second_t{durations[std::distance(
+      durations.begin(),
+      std::max_element(durations.begin(), durations.end()))]};
+}
+
+void sysid::InitialTrimAndFilter(
+    wpi::StringMap<std::vector<PreparedData>>* data,
+    AnalysisManager::Settings& settings, units::second_t& minStepTime,
+    units::second_t& maxStepTime, wpi::StringRef unit) {
+  auto& preparedData = *data;
+
+  // Trim quasistatic test data to remove all points where voltage is zero or
+  // velocity < motion threshold.
+  sysid::ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        sysid::TrimQuasistaticData(&preparedData[key],
+                                   settings.motionThreshold);
+      },
+      [](wpi::StringRef key) { return key.contains("slow"); });
+
+  // Apply Median filter
+  sysid::ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        sysid::ApplyMedianFilter(&preparedData[key], settings.windowSize);
+      },
+      [](wpi::StringRef key) { return !key.startswith("raw"); });
+
+  // Recalculate Accel and Cosine
+  sysid::ApplyToData(preparedData, [&](wpi::StringRef key) {
+    PrepareMechData(&preparedData[key], settings.windowSize, unit);
+  });
+
+  // Find the maximum Step Test Duration
+  maxStepTime = GetMaxTime(preparedData);
+
+  // Trims all Dynamic Test Data but excludes raw data from calculation of
+  // minimum step time
+  sysid::ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        auto tempMinStepTime = sysid::TrimStepVoltageData(
+            &preparedData[key], &settings, minStepTime, maxStepTime);
+        if (!key.startswith("raw")) {
+          minStepTime = tempMinStepTime;
+        }
+      },
+      [](wpi::StringRef key) { return key.contains("fast"); });
+  // Confirm there's still data
+  if (std::any_of(preparedData.begin(), preparedData.end(),
+                  [](const auto& it) { return it.first().empty(); })) {
+    throw std::runtime_error("Trimming removed all data");
+  }
+}
+
+/**
+ * Trims data with dt too far from mean.
+ *
+ * @param data      The data to filter.
+ * @param dtMean    The mean dt.
+ * @param tolerance The tolerance outside of which to trim.
+ */
+static void TrimByTimeDelta(std::vector<PreparedData>* data,
+                            units::second_t dtMean, units::second_t tolerance) {
+  data->erase(std::remove_if(data->begin(), data->end(),
+                             [dtMean, tolerance](const auto& pt) {
+                               return units::math::abs(pt.dt - dtMean) >
+                                      tolerance;
+                             }),
+              data->end());
+}
+
+void sysid::AccelAndTimeFilter(wpi::StringMap<std::vector<PreparedData>>* data,
+                               const Storage& tempCombined) {
+  auto& preparedData = *data;
+  units::second_t dtMean = GetMeanTimeDelta(tempCombined);
+
+  // Remove points with dt too far from mean
+  sysid::ApplyToData(
+      preparedData,
+      [&](wpi::StringRef key) {
+        TrimByTimeDelta(&preparedData[key], dtMean, 1_ms);
+      },
+      [](wpi::StringRef key) { return !key.startswith("raw"); });
+
+  // Remove points with accel = 0
+  sysid::ApplyToData(preparedData, [&](wpi::StringRef key) {
+    FilterAccelData(&preparedData[key]);
+  });
+
+  // Confirm there's still data
+  if (std::any_of(preparedData.begin(), preparedData.end(),
+                  [](const auto& it) { return it.first().empty(); })) {
+    throw std::runtime_error("Trimming removed all data");
   }
 }

--- a/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -55,8 +55,8 @@ static std::vector<std::vector<ImPlotPoint>> PopulateTimeDomainSim(
     // If the current time stamp and previous time stamp are across a test's
     // start timestamp, it is the start of a new test and the model needs to be
     // reset.
-    if (now.dt < 0_s || std::find(startTimes.begin(), startTimes.end(),
-                                  now.timestamp) != startTimes.end()) {
+    if (std::find(startTimes.begin(), startTimes.end(), now.timestamp) !=
+        startTimes.end()) {
       pts.emplace_back(std::move(tmp));
       model.Reset(now.position, now.velocity);
       continue;
@@ -264,19 +264,19 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
   if (type == analysis::kElevator) {
     const auto& Kg = ffGains[3];
     m_quasistaticSim = PopulateTimeDomainSim(
-        slow, startTimes, fastStep, sysid::ElevatorSim{Ks, Kv, Ka, Kg});
-    m_dynamicSim = PopulateTimeDomainSim(fast, startTimes, fastStep,
+        rawSlow, startTimes, fastStep, sysid::ElevatorSim{Ks, Kv, Ka, Kg});
+    m_dynamicSim = PopulateTimeDomainSim(rawFast, startTimes, fastStep,
                                          sysid::ElevatorSim{Ks, Kv, Ka, Kg});
   } else if (type == analysis::kArm) {
     const auto& Kcos = ffGains[3];
-    m_quasistaticSim = PopulateTimeDomainSim(slow, startTimes, fastStep,
+    m_quasistaticSim = PopulateTimeDomainSim(rawSlow, startTimes, fastStep,
                                              sysid::ArmSim{Ks, Kv, Ka, Kcos});
-    m_dynamicSim = PopulateTimeDomainSim(fast, startTimes, fastStep,
+    m_dynamicSim = PopulateTimeDomainSim(rawFast, startTimes, fastStep,
                                          sysid::ArmSim{Ks, Kv, Ka, Kcos});
   } else {
-    m_quasistaticSim = PopulateTimeDomainSim(slow, startTimes, fastStep,
+    m_quasistaticSim = PopulateTimeDomainSim(rawSlow, startTimes, fastStep,
                                              sysid::SimpleMotorSim{Ks, Kv, Ka});
-    m_dynamicSim = PopulateTimeDomainSim(fast, startTimes, fastStep,
+    m_dynamicSim = PopulateTimeDomainSim(rawFast, startTimes, fastStep,
                                          sysid::SimpleMotorSim{Ks, Kv, Ka});
   }
 

--- a/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include <frc/MedianFilter.h>
 #include <units/time.h>
 
 #include "sysid/analysis/AnalysisManager.h"
@@ -23,23 +22,11 @@ namespace sysid {
  * Trims quasistatic data so that no point has a voltage of zero or a velocity
  * less than the motion threshold.
  *
- * @tparam S        The size of the raw data array.
- * @tparam Voltage  The index of the voltage entry in the raw data.
- * @tparam Velocity The index of the velocity entry in the raw data.
- *
- * @param data            A pointer to the vector of raw data.
+ * @param data            A pointer to the vector of the prepared data.
  * @param motionThreshold The velocity threshold under which to delete data.
  */
-template <size_t S, size_t Voltage, size_t Velocity>
-void TrimQuasistaticData(std::vector<std::array<double, S>>* data,
-                         double motionThreshold) {
-  data->erase(std::remove_if(data->begin(), data->end(),
-                             [motionThreshold](const auto& pt) {
-                               return std::abs(pt[Voltage]) <= 0 ||
-                                      std::abs(pt[Velocity]) < motionThreshold;
-                             }),
-              data->end());
-}
+void TrimQuasistaticData(std::vector<PreparedData>* data,
+                         double motionThreshold);
 
 /**
  * Calculates the expected acceleration noise to be used as the floor of the
@@ -48,6 +35,8 @@ void TrimQuasistaticData(std::vector<std::array<double, S>>* data,
  *
  * @param data the prepared data vector containing acceleration data
  * @param window the size of the window for the moving average
+ *
+ * @return The expected acceleration noise
  */
 double GetAccelNoiseFloor(const std::vector<PreparedData>& data, int window);
 
@@ -61,21 +50,7 @@ double GetAccelNoiseFloor(const std::vector<PreparedData>& data, int window);
  * velocity data)
  * @param window the size of the window of the median filter (must be odd)
  */
-template <size_t S, size_t Velocity>
-void ApplyMedianFilter(std::vector<std::array<double, S>>* data, int window) {
-  size_t step = window / 2;
-  std::vector<std::array<double, S>> prepared;
-  frc::MedianFilter<double> medianFilter(window);
-  for (size_t i = 0; i < data->size(); i++) {
-    double median = medianFilter.Calculate(data->at(i)[Velocity]);
-    if (i > step) {
-      std::array<double, S> updateData{data->at(i - step)};
-      updateData[Velocity] = median;
-      prepared.push_back(updateData);
-    }
-  }
-  *data = std::move(prepared);
-}
+void ApplyMedianFilter(std::vector<PreparedData>* data, int window);
 
 /**
  * Trims the step voltage data to discard all points before the maximum
@@ -98,7 +73,19 @@ units::second_t TrimStepVoltageData(std::vector<PreparedData>* data,
 
 /**
  * Compute the mean time delta of the given data.
+ *
+ * @param data A reference to all of the collected PreparedData
+ *
+ * @return The mean time delta for all the data points
  */
 units::second_t GetMeanTimeDelta(const Storage& data);
+
+/**
+ * Filters out data with acceleration = 0
+ *
+ * @param data A pointer to a PreparedData vector that needs acceleration
+ *             filtering.
+ */
+void FilterAccelData(std::vector<PreparedData>* data);
 
 }  // namespace sysid

--- a/src/main/native/include/sysid/analysis/Storage.h
+++ b/src/main/native/include/sysid/analysis/Storage.h
@@ -19,10 +19,17 @@ struct PreparedData {
   double voltage;
   double position;
   double velocity;
-  double nextVelocity;
-  units::second_t dt;
-  double acceleration;
-  double cos;
+  double nextVelocity = 0.0;
+  units::second_t dt = 0_s;
+  double acceleration = 0.0;
+  double cos = 0.0;
+
+  constexpr bool operator==(const PreparedData& rhs) const {
+    return timestamp == rhs.timestamp && voltage == rhs.voltage &&
+           position == rhs.position && velocity == rhs.velocity &&
+           nextVelocity == rhs.nextVelocity && dt == rhs.dt &&
+           acceleration == rhs.acceleration && cos == rhs.cos;
+  }
 };
 
 /**

--- a/src/test/native/cpp/analysis/FilterTest.cpp
+++ b/src/test/native/cpp/analysis/FilterTest.cpp
@@ -11,22 +11,34 @@
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/FeedforwardAnalysis.h"
 #include "sysid/analysis/FilteringUtils.h"
+#include "sysid/analysis/Storage.h"
 
 TEST(FilterTest, MedianFilter) {
-  std::vector<std::array<double, 1>> testData = {{0}, {1},    {10}, {5}, {3},
-                                                 {0}, {1000}, {7},  {6}, {5}};
-  std::vector<std::array<double, 1>> expectedData = {{1}, {5}, {5}, {3},
-                                                     {3}, {7}, {7}, {6}};
+  std::vector<sysid::PreparedData> testData{
+      sysid::PreparedData{0_s, 0, 0, 0},    sysid::PreparedData{0_s, 0, 0, 1},
+      sysid::PreparedData{0_s, 0, 0, 10},   sysid::PreparedData{0_s, 0, 0, 5},
+      sysid::PreparedData{0_s, 0, 0, 3},    sysid::PreparedData{0_s, 0, 0, 0},
+      sysid::PreparedData{0_s, 0, 0, 1000}, sysid::PreparedData{0_s, 0, 0, 7},
+      sysid::PreparedData{0_s, 0, 0, 6},    sysid::PreparedData{0_s, 0, 0, 5}};
+  std::vector<sysid::PreparedData> expectedData{
+      sysid::PreparedData{0_s, 0, 0, 0}, sysid::PreparedData{0_s, 0, 0, 1},
+      sysid::PreparedData{0_s, 0, 0, 5}, sysid::PreparedData{0_s, 0, 0, 5},
+      sysid::PreparedData{0_s, 0, 0, 3}, sysid::PreparedData{0_s, 0, 0, 3},
+      sysid::PreparedData{0_s, 0, 0, 7}, sysid::PreparedData{0_s, 0, 0, 7},
+      sysid::PreparedData{0_s, 0, 0, 6}, sysid::PreparedData{0_s, 0, 0, 5}};
 
-  sysid::ApplyMedianFilter<1, 0>(&testData, 3);
+  sysid::ApplyMedianFilter(&testData, 3);
   EXPECT_EQ(expectedData, testData);
 }
 
 TEST(FilterTest, QuasistaticTrim) {
-  std::vector<std::array<double, 2>> testData = {
-      {0, 1}, {.5, 2}, {2, 0.1}, {4, 4}, {0, 5}};
-  std::vector<std::array<double, 2>> expectedData = {{.5, 2}, {4, 4}};
-  sysid::TrimQuasistaticData<2, 0, 1>(&testData, 0.2);
+  std::vector<sysid::PreparedData> testData{
+      {sysid::PreparedData{0_s, 0, 0, 1}, sysid::PreparedData{0_s, .5, 0, 2},
+       sysid::PreparedData{0_s, 2, 0, 0.1}, sysid::PreparedData{0_s, 4, 0, 4},
+       sysid::PreparedData{0_s, 0, 0, 5}}};
+  std::vector<sysid::PreparedData> expectedData{
+      sysid::PreparedData{0_s, .5, 0, 2}, sysid::PreparedData{0_s, 4, 0, 4}};
+  sysid::TrimQuasistaticData(&testData, 0.2);
   EXPECT_EQ(expectedData, testData);
 }
 


### PR DESCRIPTION
Converts the raw data into the PreparedData struct once the data is
loaded. This reduces the number of template functions and makes the data
pipeline cleaner.

- [x] Fix the sim graphs getting messed up for some of the data.
- [x] Mac elevator fails