### PR TITLE
Fix filtered data lag in plots

### DIFF
--- a/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -133,10 +133,13 @@ static void PrepareGeneralData(const wpi::json& json,
   }
 
   // Loads the Raw Data
-  sysid::ApplyToData(data, [&](wpi::StringRef key) {
-    std::string rawName{"raw-" + key.str()};
-    data[rawName] = std::vector<Data>(data[key]);
-  });
+  sysid::ApplyToData(
+      data,
+      [&](wpi::StringRef key) {
+        std::string rawName{"raw-" + key.str()};
+        data[rawName] = std::vector<Data>(data[key]);
+      },
+      [](wpi::StringRef key) { return !key.contains("raw"); });
 
   // Convert data to PreparedData structs
   sysid::ApplyToData(data, [&](wpi::StringRef key) {
@@ -319,10 +322,13 @@ static void PrepareLinearDrivetrainData(
   }
 
   // Load Raw Data
-  sysid::ApplyToData(data, [&](wpi::StringRef key) {
-    std::string rawName{"raw-" + key.str()};
-    data[rawName] = std::vector<Data>(data[key]);
-  });
+  sysid::ApplyToData(
+      data,
+      [&](wpi::StringRef key) {
+        std::string rawName{"raw-" + key.str()};
+        data[rawName] = std::vector<Data>(data[key]);
+      },
+      [](wpi::StringRef key) { return !key.contains("raw"); });
 
   // Convert data to PreparedData
   sysid::ApplyToData(data, [&](wpi::StringRef key) {

--- a/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <units/time.h>
+#include <wpi/StringRef.h>
 
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/Storage.h"


### PR DESCRIPTION
Resolves #132 

Uses Timestamp instead of dts to plot the data.

Also fixes some additional bugs in the current analysis pipeline.

![image](https://user-images.githubusercontent.com/29788153/117557652-01853c00-b03b-11eb-989e-bdae1d79a608.png)
