### PR TITLE
Reset motor voltages at test's end

### DIFF
--- a/project_utils/cpp/logging/SysIdLogger.cpp
+++ b/project_utils/cpp/logging/SysIdLogger.cpp
@@ -31,9 +31,6 @@ void SysIdLogger::InitLogging() {
   m_voltageCommand = frc::SmartDashboard::GetNumber("SysIdVoltageCommand", 0.0);
   m_testType = frc::SmartDashboard::GetString("SysIdTestType", "");
   m_startTime = frc2::Timer::GetFPGATimestamp().to<double>();
-
-  // Reset telemetry string
-  // frc::SmartDashboard::PutString("SysIdTelemetry", "");
   m_data.clear();
 }
 
@@ -53,6 +50,8 @@ void SysIdLogger::SendData() {
   m_motorVoltage = 0.0;
   m_timestamp = 0.0;
   m_startTime = 0.0;
+  m_primaryMotorVoltage = 0_V;
+  m_secondaryMotorVoltage = 0_V;
 }
 
 void SysIdLogger::UpdateThreadPriority() {


### PR DESCRIPTION
When a test finished, it wouldn't reset the commanded voltage variables causing inaccurate data collection:

(Do note these are two different datasets, but the point still holds)

Before:
![image](https://user-images.githubusercontent.com/29788153/117758627-00454200-b1e8-11eb-91bf-0d54138a9806.png)

After:
![image](https://user-images.githubusercontent.com/29788153/117758641-089d7d00-b1e8-11eb-997c-a52f60bcb547.png)
