### PR TITLE
Set a maximum data collection duration

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Logger.cpp
+++ b/sysid-application/src/main/native/cpp/view/Logger.cpp
@@ -155,7 +155,7 @@ void Logger::Display() {
         m_opened = text;
       }
       if (m_opened == text && ImGui::BeginPopupModal("Warning")) {
-        ImGui::Text("%s", m_popupText.c_str());
+        ImGui::TextWrapped("%s", m_popupText.c_str());
         if (ImGui::Button(m_manager->IsActive() ? "End Test" : "Close")) {
           m_manager->EndTest();
           ImGui::CloseCurrentPopup();

--- a/sysid-application/src/main/native/include/sysid/telemetry/TelemetryManager.h
+++ b/sysid-application/src/main/native/include/sysid/telemetry/TelemetryManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <utility>
@@ -116,6 +117,8 @@ class TelemetryManager {
     return std::find(m_tests.cbegin(), m_tests.cend(), name) != m_tests.end();
   }
 
+  size_t GetCurrentDataSize() const { return m_params.data.size(); }
+
  private:
   enum class State { WaitingForEnable, RunningTest, WaitingForData };
 
@@ -141,6 +144,7 @@ class TelemetryManager {
 
     std::string raw;
     std::vector<std::vector<double>> data{};
+    bool overflow = false;
 
     TestParameters() = default;
     TestParameters(bool fast, bool forward, bool rotate, State state)
@@ -173,6 +177,7 @@ class TelemetryManager {
   NT_Entry m_testType;
   NT_Entry m_rotate;
   NT_Entry m_telemetry;
+  NT_Entry m_overflow;
   NT_Entry m_telemetryOld;
   NT_Entry m_mechanism;
   NT_Entry m_fieldInfo;

--- a/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
@@ -19,16 +19,18 @@ void SysIdDrivetrainLogger::Log(double leftPosition, double rightPosition,
                                 double leftVelocity, double rightVelocity,
                                 double measuredAngle, double angularRate) {
   UpdateData();
-  std::array<double, 9> arr = {m_timestamp,
-                               m_primaryMotorVoltage.to<double>(),
-                               m_secondaryMotorVoltage.to<double>(),
-                               leftPosition,
-                               rightPosition,
-                               leftVelocity,
-                               rightVelocity,
-                               measuredAngle,
-                               angularRate};
-  m_data.insert(m_data.end(), arr.cbegin(), arr.cend());
+  if (m_data.size() < kDataVectorSize) {
+    std::array<double, 9> arr = {m_timestamp,
+                                 m_primaryMotorVoltage.to<double>(),
+                                 m_secondaryMotorVoltage.to<double>(),
+                                 leftPosition,
+                                 rightPosition,
+                                 leftVelocity,
+                                 rightVelocity,
+                                 measuredAngle,
+                                 angularRate};
+    m_data.insert(m_data.end(), arr.cbegin(), arr.cend());
+  }
 
   m_primaryMotorVoltage = units::volt_t{(m_rotate ? -1 : 1) * m_motorVoltage};
   m_secondaryMotorVoltage = units::volt_t{m_motorVoltage};

--- a/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
@@ -14,8 +14,12 @@ units::volt_t SysIdGeneralMechanismLogger::GetMotorVoltage() {
 void SysIdGeneralMechanismLogger::Log(double measuredPosition,
                                       double measuredVelocity) {
   UpdateData();
-  std::array<double, 4> arr = {m_timestamp, m_primaryMotorVoltage.to<double>(),
-                               measuredPosition, measuredVelocity};
-  m_data.insert(m_data.end(), arr.cbegin(), arr.cend());
+  if (m_data.size() < kDataVectorSize) {
+    std::array<double, 4> arr = {m_timestamp,
+                                 m_primaryMotorVoltage.to<double>(),
+                                 measuredPosition, measuredVelocity};
+    m_data.insert(m_data.end(), arr.cbegin(), arr.cend());
+  }
+
   m_primaryMotorVoltage = units::volt_t{m_motorVoltage};
 }

--- a/sysid-library/src/main/cpp/logging/SysIdLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdLogger.cpp
@@ -22,8 +22,8 @@ SysIdLogger::SysIdLogger() {
   frc::LiveWindow::GetInstance()->DisableAllTelemetry();
   frc::SmartDashboard::PutNumber("SysIdVoltageCommand", 0.0);
   frc::SmartDashboard::PutString("SysIdTestType", "");
-  // frc::SmartDashboard::PutString("SysIdTelemetry", "");
   frc::SmartDashboard::PutBoolean("SysIdRotate", false);
+  frc::SmartDashboard::PutBoolean("SysIdOverflow", false);
 }
 
 void SysIdLogger::InitLogging() {
@@ -37,6 +37,9 @@ void SysIdLogger::InitLogging() {
 void SysIdLogger::SendData() {
   wpi::outs() << "Collected: " << m_data.size() << " Data points.\n";
   wpi::outs().flush();
+
+  frc::SmartDashboard::PutBoolean("SysIdOverflow",
+                                  m_data.size() >= kDataVectorSize);
 
   std::stringstream ss;
   for (const auto& pt : m_data) {

--- a/sysid-library/src/main/include/logging/SysIdLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdLogger.h
@@ -43,6 +43,11 @@ class SysIdLogger {
   std::string m_testType;
   std::vector<double> m_data;
 
+  // 20 seconds of test data * 200 samples/second * 9 doubles/sample (320kB of
+  // reserved data) provides a large initial vector size to avoid reallocating
+  // during a test
+  static constexpr size_t kDataVectorSize = 36000;
+
   /**
    * Updates the autospeed and robotVoltage
    */
@@ -51,9 +56,4 @@ class SysIdLogger {
  private:
   static constexpr int kThreadPriority = 15;
   static constexpr int kHALThreadPriority = 40;
-
-  // 20 seconds of test data * 200 samples/second * 10 doubles/sample (320kB of
-  // reserved data) provides a large initial vector size to avoid reallocating
-  // during a test
-  static constexpr size_t kDataVectorSize = 40000;
 };


### PR DESCRIPTION
To prevent issues such as #55 and https://github.com/wpilibsuite/frc-characterization/issues/195, the vector storing the collected data now stops after a certain threshold is reached.

Fixes #55 

The sample drivetrain test below was run for several minutes, but only the first 20 seconds of the data were sent.
![image](https://user-images.githubusercontent.com/29788153/119279528-ea754b00-bbf1-11eb-9e76-c3a5c1c2792c.png)
