### PR TITLE
Add more gyro constructors to generation test

### DIFF
--- a/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
+++ b/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
@@ -31,8 +31,10 @@ using namespace std::chrono_literals;
 
 const wpi::SmallVector<std::string, 4> kPigeonCtors{"0", "WPI_TalonSRX-1"};
 const wpi::SmallVector<std::string, 4> kAnalogCtors{"0"};
-const wpi::SmallVector<std::string, 4> kNavXCtors{"SPI.kMXP"};
-const wpi::SmallVector<std::string, 4> kADXRS450Ctors{"SPI.kMXP"};
+const wpi::SmallVector<std::string, 4> kNavXCtors{
+    "SerialPort.kUSB", "I2C", "SerialPort.kMXP", "SPI.kMXP"};
+const wpi::SmallVector<std::string, 4> kADXRS450Ctors{"SPI.kMXP",
+                                                      "kOnboardCS0"};
 wpi::StringMap<wpi::SmallVector<std::string, 4>> gyroCtorMap = {
     {"AnalogGyro", kAnalogCtors},
     {"Pigeon", kPigeonCtors},
@@ -105,7 +107,7 @@ class GenerationTest : public ::testing::Test {
 };
 wpi::Logger GenerationTest::m_logger;
 
-TEST_F(GenerationTest, SingleSided) {
+TEST_F(GenerationTest, GeneralMechanism) {
   SetUp("sysid-projects:mechanism");
   constexpr size_t size = 2;
   for (auto&& motorController : sysid::kMotorControllers) {


### PR DESCRIPTION
The number of gyro constructors that were being tested had been reduced because it added too many additional permutations to the old test setup (tested different motor controllers+ gyros + encoders on top of the analysis test). Now that the drive tests are separate and serve to essentially just test the gyros (motor controllers + encoders are tested in GeneralMechanism), these additional constructors can be tested.