### PR TITLE
Disable analysis when an exception is thrown

### DIFF
--- a/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -15,6 +15,21 @@
 using namespace sysid;
 
 /**
+ * Helper function that throws if it detects that the data vector is too small
+ * for an operation of a certain window size.
+ *
+ * @param data The data that is being used.
+ * @param window The window size for the operation.
+ */
+static void CheckSize(const std::vector<PreparedData>& data, int window) {
+  if (data.size() < window) {
+    throw std::runtime_error(
+        "The data collected is too small! This can be caused by too high of a "
+        "motion threshold or bad data collection.");
+  }
+}
+
+/**
  * Fills in the rest of the PreparedData Structs for a PreparedData Vector.
  *
  * @param data A reference to a vector of the raw data.
@@ -26,11 +41,7 @@ static void PrepareMechData(std::vector<PreparedData>* data,
   constexpr size_t kOrder = 6;
   constexpr size_t kWindow = kOrder + 1;
 
-  if (data->size() < kWindow) {
-    throw std::runtime_error(
-        "The data collected is too small! This can be caused by too high of a "
-        "motion threshold or bad data collection.");
-  }
+  CheckSize(*data, kWindow);
 
   const double h = GetMeanTimeDelta(*data).to<double>();
 
@@ -159,6 +170,8 @@ void sysid::TrimQuasistaticData(std::vector<PreparedData>* data,
 }
 
 void sysid::ApplyMedianFilter(std::vector<PreparedData>* data, int window) {
+  CheckSize(*data, window);
+
   size_t step = window / 2;
   frc::MedianFilter<double> medianFilter(window);
 

--- a/sysid-application/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid-application/src/main/native/include/sysid/view/Analyzer.h
@@ -51,6 +51,7 @@ class Analyzer : public glass::View {
   void AbortDataPrep();
   void DisplayFeedforwardGains(bool combined = false);
   void ConfigParamsOnFileSelect();
+  void DisplayGain(const char* text, double* data);
 
   /**
    * Loads the diagnostic plots.
@@ -59,6 +60,12 @@ class Analyzer : public glass::View {
    * have just finished loading.
    */
   bool LoadPlots();
+
+  // This is true when the analysis is allowed to occur.
+  bool m_enabled = true;
+
+  // This is true if the error popup needs to be displayed
+  bool m_errorPopup = false;
 
   bool first = true;
   std::string m_exception;


### PR DESCRIPTION
Whenever an exception is caught, the tool disables data analysis until a feedforward value is changed. This lets users change the data without having to reload the file.

Fixes #74