### PR TITLE
Define NDEBUG in release mode

### DIFF
--- a/sysid-application/build.gradle
+++ b/sysid-application/build.gradle
@@ -159,6 +159,11 @@ model {
       } else {
         it.linker.args << '-lX11'
       }
+
+      // Define NDEBUG in Release Mode (needed for proper wpi::Logger functionality).
+      if (it.buildType.getName() == "release") {
+        it.cppCompiler.define("NDEBUG")
+      }
     }
   }
   tasks {


### PR DESCRIPTION
For debug messages to be hidden in release mode, wpi::Logger requires
NDEBUG to be defined.