### PR TITLE
Clean up sysid-library logging classes

### DIFF
--- a/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
@@ -5,13 +5,12 @@
 #include "logging/SysIdDrivetrainLogger.h"
 
 #include <frc/smartdashboard/SmartDashboard.h>
-#include <units/voltage.h>
 
-units::volt_t SysIdDrivetrainLogger::GetLeftMotorVoltage() {
+units::volt_t SysIdDrivetrainLogger::GetLeftMotorVoltage() const {
   return m_primaryMotorVoltage;
 }
 
-units::volt_t SysIdDrivetrainLogger::GetRightMotorVoltage() {
+units::volt_t SysIdDrivetrainLogger::GetRightMotorVoltage() const {
   return m_secondaryMotorVoltage;
 }
 
@@ -34,4 +33,10 @@ void SysIdDrivetrainLogger::Log(double leftPosition, double rightPosition,
 
   m_primaryMotorVoltage = units::volt_t{(m_rotate ? -1 : 1) * m_motorVoltage};
   m_secondaryMotorVoltage = units::volt_t{m_motorVoltage};
+}
+
+void SysIdDrivetrainLogger::Reset() {
+  SysIdLogger::Reset();
+  m_primaryMotorVoltage = 0_V;
+  m_secondaryMotorVoltage = 0_V;
 }

--- a/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
@@ -5,9 +5,8 @@
 #include "logging/SysIdGeneralMechanismLogger.h"
 
 #include <frc/smartdashboard/SmartDashboard.h>
-#include <units/voltage.h>
 
-units::volt_t SysIdGeneralMechanismLogger::GetMotorVoltage() {
+units::volt_t SysIdGeneralMechanismLogger::GetMotorVoltage() const {
   return m_primaryMotorVoltage;
 }
 
@@ -22,4 +21,9 @@ void SysIdGeneralMechanismLogger::Log(double measuredPosition,
   }
 
   m_primaryMotorVoltage = units::volt_t{m_motorVoltage};
+}
+
+void SysIdGeneralMechanismLogger::Reset() {
+  SysIdLogger::Reset();
+  m_primaryMotorVoltage = 0_V;
 }

--- a/sysid-library/src/main/cpp/logging/SysIdLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdLogger.cpp
@@ -15,15 +15,6 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <frc2/Timer.h>
 
-SysIdLogger::SysIdLogger() {
-  m_data.reserve(kDataVectorSize);
-  frc::LiveWindow::GetInstance()->DisableAllTelemetry();
-  frc::SmartDashboard::PutNumber("SysIdVoltageCommand", 0.0);
-  frc::SmartDashboard::PutString("SysIdTestType", "");
-  frc::SmartDashboard::PutBoolean("SysIdRotate", false);
-  frc::SmartDashboard::PutBoolean("SysIdOverflow", false);
-}
-
 void SysIdLogger::InitLogging() {
   m_rotate = frc::SmartDashboard::GetBoolean("SysIdRotate", false);
   m_voltageCommand = frc::SmartDashboard::GetNumber("SysIdVoltageCommand", 0.0);
@@ -49,13 +40,7 @@ void SysIdLogger::SendData() {
 
   frc::SmartDashboard::PutString("SysIdTelemetry", ss.str());
 
-  // Clear everything after test
-  m_data.clear();
-  m_motorVoltage = 0.0;
-  m_timestamp = 0.0;
-  m_startTime = 0.0;
-  m_primaryMotorVoltage = 0_V;
-  m_secondaryMotorVoltage = 0_V;
+  Reset();
 }
 
 void SysIdLogger::UpdateThreadPriority() {
@@ -67,6 +52,15 @@ void SysIdLogger::UpdateThreadPriority() {
   }
 }
 
+SysIdLogger::SysIdLogger() {
+  m_data.reserve(kDataVectorSize);
+  frc::LiveWindow::GetInstance()->DisableAllTelemetry();
+  frc::SmartDashboard::PutNumber("SysIdVoltageCommand", 0.0);
+  frc::SmartDashboard::PutString("SysIdTestType", "");
+  frc::SmartDashboard::PutBoolean("SysIdRotate", false);
+  frc::SmartDashboard::PutBoolean("SysIdOverflow", false);
+}
+
 void SysIdLogger::UpdateData() {
   m_timestamp = frc2::Timer::GetFPGATimestamp().to<double>();
   if (m_testType == "Quasistatic") {
@@ -76,4 +70,11 @@ void SysIdLogger::UpdateData() {
   } else {
     m_motorVoltage = 0.0;
   }
+}
+
+void SysIdLogger::Reset() {
+  m_motorVoltage = 0.0;
+  m_timestamp = 0.0;
+  m_startTime = 0.0;
+  m_data.clear();
 }

--- a/sysid-library/src/main/include/logging/SysIdDrivetrainLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdDrivetrainLogger.h
@@ -14,13 +14,13 @@ class SysIdDrivetrainLogger : public SysIdLogger {
   /**
    * The users should their left motors to what this returns AFTER calling log.
    */
-  units::volt_t GetLeftMotorVoltage();
+  units::volt_t GetLeftMotorVoltage() const;
 
   /**
    * The users should set their right motors to what this returns AFTER calling
    * log.
    */
-  units::volt_t GetRightMotorVoltage();
+  units::volt_t GetRightMotorVoltage() const;
 
   /**
    * Logs data for a drivetrain mechanism.
@@ -38,4 +38,10 @@ class SysIdDrivetrainLogger : public SysIdLogger {
    */
   void Log(double leftPosition, double rightPosition, double leftVelocity,
            double rightVelocity, double measuredAngle, double angularRate);
+
+  void Reset() override;
+
+ private:
+  units::volt_t m_primaryMotorVoltage = 0_V;
+  units::volt_t m_secondaryMotorVoltage = 0_V;
 };

--- a/sysid-library/src/main/include/logging/SysIdGeneralMechanismLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdGeneralMechanismLogger.h
@@ -14,7 +14,7 @@ class SysIdGeneralMechanismLogger : public SysIdLogger {
   /**
    * The users should set their motors to what this returns AFTER calling log.
    */
-  units::volt_t GetMotorVoltage();
+  units::volt_t GetMotorVoltage() const;
 
   /**
    * Logs data for a single-sided mechanism (Elevator, Simple, Arm).
@@ -25,4 +25,9 @@ class SysIdGeneralMechanismLogger : public SysIdLogger {
    * @param measureVelocity the recorded rotations per second of the shaft
    */
   void Log(double measuredPosition, double measuredVelocity);
+
+  void Reset() override;
+
+ private:
+  units::volt_t m_primaryMotorVoltage = 0_V;
 };

--- a/sysid-library/src/main/include/logging/SysIdLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdLogger.h
@@ -8,51 +8,52 @@
 #include <string>
 #include <vector>
 
-#include <units/voltage.h>
-
 class SysIdLogger {
  public:
+  void InitLogging();
+
   /**
    * Sends data after logging is complete.
-   * Called in DisabledInit();
+   *
+   * Called in DisabledInit().
    */
   void SendData();
 
   /**
-   * Makes the current execution thread of the logger a realtime thread which
-   * ensures that the logging loop will consistently meet its loop time (ideally
-   * 5 ms).
+   * Makes the current execution thread of the logger a real-time thread which
+   * will make it scheduled more consistently.
    */
-  void UpdateThreadPriority();
-
-  void InitLogging();
+  static void UpdateThreadPriority();
 
  protected:
+  // 20 seconds of test data * 200 samples/second * 9 doubles/sample (320kB of
+  // reserved data) provides a large initial vector size to avoid reallocating
+  // during a test
+  static constexpr size_t kDataVectorSize = 36000;
+
+  double m_voltageCommand = 0.0;
+  double m_motorVoltage = 0.0;
+  double m_timestamp = 0.0;
+  double m_startTime = 0.0;
+  bool m_rotate = false;
+  std::string m_testType;
+  std::vector<double> m_data;
+
   /**
    * Creates the SysId logger, disables live view telemetry, sets up the
    * following NT Entries: "SysIdAutoSpeed", "SysIdRotate", "SysIdTelemetry"
    */
   SysIdLogger();
 
-  units::volt_t m_primaryMotorVoltage;
-  units::volt_t m_secondaryMotorVoltage;
-  double m_voltageCommand;
-  double m_motorVoltage;
-  double m_timestamp;
-  double m_startTime;
-  bool m_rotate;
-  std::string m_testType;
-  std::vector<double> m_data;
-
-  // 20 seconds of test data * 200 samples/second * 9 doubles/sample (320kB of
-  // reserved data) provides a large initial vector size to avoid reallocating
-  // during a test
-  static constexpr size_t kDataVectorSize = 36000;
-
   /**
    * Updates the autospeed and robotVoltage
    */
   void UpdateData();
+
+  /**
+   * Reset data before next test.
+   */
+  virtual void Reset();
 
  private:
   static constexpr int kThreadPriority = 15;


### PR DESCRIPTION
* Const qualify getters
* Sort constants before member variables before functions
* Sort functions in the same order between headers and source files
* Move voltage storage into derived classes that use them