### PR TITLE
Fix deployed JSON generation

### DIFF
--- a/sysid-application/src/main/native/cpp/deploy/DeploySession.cpp
+++ b/sysid-application/src/main/native/cpp/deploy/DeploySession.cpp
@@ -43,7 +43,7 @@ wpi::mutex s_mutex;
 
 DeploySession::DeploySession(std::string_view team, bool drive,
                              wpi::json config, wpi::Logger& logger)
-    : m_drive{drive}, m_config{std::move(config)}, m_logger{logger} {
+    : m_drive{drive}, m_config(std::move(config)), m_logger{logger} {
   // Check whether we have an IP/hostname or team number.
   auto maybeTeam = wpi::parse_integer<int>(team, 10);
 

--- a/sysid-application/src/main/native/include/sysid/deploy/DeploySession.h
+++ b/sysid-application/src/main/native/include/sysid/deploy/DeploySession.h
@@ -64,6 +64,11 @@ class DeploySession {
    */
   static std::vector<std::string> GetAddressesToTry(int team);
 
+  /**
+   * Returns the stored JSON object
+   */
+  const wpi::json& GetJSON() const { return m_config; }
+
  private:
   // General deploy parameters from the constructor.
   bool m_drive;

--- a/sysid-application/src/test/native/cpp/deploy/DeployJSONTest.cpp
+++ b/sysid-application/src/test/native/cpp/deploy/DeployJSONTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <wpi/Logger.h>
+#include <wpi/json.h>
+
+#include "gtest/gtest.h"
+#include "sysid/deploy/DeploySession.h"
+#include "sysid/generation/ConfigManager.h"
+
+TEST(DeployTest, JSONGeneration) {
+  wpi::Logger m_logger;
+  sysid::ConfigSettings m_config;
+  sysid::ConfigManager m_configManager{m_config, m_logger};
+  sysid::DeploySession m_session{"0", false, m_configManager.Generate(1),
+                                 m_logger};
+
+  const auto& json = m_session.GetJSON();
+
+  // Verify that it is valid JSON data
+  try {
+    wpi::json::parse(json.dump());
+  } catch (wpi::json::parse_error err) {
+    FAIL();
+  }
+
+  // Make sure its an object
+  ASSERT_TRUE(json.is_object());
+}


### PR DESCRIPTION
The initializer list constructor of the json library causes config jsons
to be converted into an array type causing issues when reading it on the
rio. Tests have been added to ensure this won't happen.

Fixes #174 