### PR TITLE
Add warning for characterizing mechanisms with the wrong project

### DIFF
--- a/sysid-application/src/main/native/include/sysid/telemetry/TelemetryManager.h
+++ b/sysid-application/src/main/native/include/sysid/telemetry/TelemetryManager.h
@@ -145,6 +145,7 @@ class TelemetryManager {
     std::string raw;
     std::vector<std::vector<double>> data{};
     bool overflow = false;
+    bool mechError = false;
 
     TestParameters() = default;
     TestParameters(bool fast, bool forward, bool rotate, State state)
@@ -180,6 +181,7 @@ class TelemetryManager {
   NT_Entry m_overflow;
   NT_Entry m_telemetryOld;
   NT_Entry m_mechanism;
+  NT_Entry m_mechError;
   NT_Entry m_fieldInfo;
 };
 }  // namespace sysid

--- a/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdDrivetrainLogger.cpp
@@ -40,3 +40,7 @@ void SysIdDrivetrainLogger::Reset() {
   m_primaryMotorVoltage = 0_V;
   m_secondaryMotorVoltage = 0_V;
 }
+
+bool SysIdDrivetrainLogger::IsWrongMechanism() const {
+  return m_mechanism != "Drivetrain" && m_mechanism != "Drivetrain (Angular)";
+}

--- a/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
+++ b/sysid-library/src/main/cpp/logging/SysIdGeneralMechanismLogger.cpp
@@ -27,3 +27,8 @@ void SysIdGeneralMechanismLogger::Reset() {
   SysIdLogger::Reset();
   m_primaryMotorVoltage = 0_V;
 }
+
+bool SysIdGeneralMechanismLogger::IsWrongMechanism() const {
+  return m_mechanism != "Arm" && m_mechanism != "Elevator" &&
+         m_mechanism != "Simple";
+}

--- a/sysid-library/src/main/include/logging/SysIdDrivetrainLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdDrivetrainLogger.h
@@ -41,6 +41,8 @@ class SysIdDrivetrainLogger : public SysIdLogger {
 
   void Reset() override;
 
+  bool IsWrongMechanism() const override;
+
  private:
   units::volt_t m_primaryMotorVoltage = 0_V;
   units::volt_t m_secondaryMotorVoltage = 0_V;

--- a/sysid-library/src/main/include/logging/SysIdGeneralMechanismLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdGeneralMechanismLogger.h
@@ -28,6 +28,8 @@ class SysIdGeneralMechanismLogger : public SysIdLogger {
 
   void Reset() override;
 
+  bool IsWrongMechanism() const override;
+
  private:
   units::volt_t m_primaryMotorVoltage = 0_V;
 };

--- a/sysid-library/src/main/include/logging/SysIdLogger.h
+++ b/sysid-library/src/main/include/logging/SysIdLogger.h
@@ -37,6 +37,7 @@ class SysIdLogger {
   double m_startTime = 0.0;
   bool m_rotate = false;
   std::string m_testType;
+  std::string m_mechanism;
   std::vector<double> m_data;
 
   /**
@@ -54,6 +55,11 @@ class SysIdLogger {
    * Reset data before next test.
    */
   virtual void Reset();
+
+  /**
+   * Returns true if the logger is characterizing an unsupported mechanism type.
+   */
+  virtual bool IsWrongMechanism() const = 0;
 
  private:
   static constexpr int kThreadPriority = 15;

--- a/sysid-projects/drive/src/main/cpp/Robot.cpp
+++ b/sysid-projects/drive/src/main/cpp/Robot.cpp
@@ -13,6 +13,7 @@
 #include <frc/ADXRS450_Gyro.h>
 #include <frc/AnalogGyro.h>
 // #include <frc/romi/RomiGyro.h>
+#include <frc/simulation/DriverStationSim.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <units/angle.h>
 #include <units/angular_velocity.h>
@@ -189,6 +190,7 @@ Robot::Robot() : frc::TimedRobot(5_ms) {
   m_logger.UpdateThreadPriority();
 
 #ifdef INTEGRATION
+  frc::SmartDashboard::PutBoolean("SysIdRun", false);
   // TODO use std::exit or EndCompetition once CTRE bug is fixed
   std::set_terminate([]() { std::_Exit(0); });
 #endif
@@ -261,6 +263,12 @@ void Robot::DisabledInit() {
 
 void Robot::SimulationPeriodic() {
 #ifdef INTEGRATION
+
+  bool enable = frc::SmartDashboard::GetBoolean("SysIdRun", false);
+  frc::sim::DriverStationSim::SetAutonomous(enable);
+  frc::sim::DriverStationSim::SetEnabled(enable);
+  frc::sim::DriverStationSim::NotifyNewData();
+
   if (frc::SmartDashboard::GetBoolean("SysIdKill", false)) {
     // TODO use std::exit or EndCompetition once CTRE bug is fixed
     std::terminate();

--- a/sysid-projects/mechanism/src/main/cpp/Robot.cpp
+++ b/sysid-projects/mechanism/src/main/cpp/Robot.cpp
@@ -8,6 +8,7 @@
 #include <exception>
 #include <string>
 
+#include <frc/simulation/DriverStationSim.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <rev/CANEncoder.h>
 #include <units/voltage.h>
@@ -61,6 +62,7 @@ Robot::Robot() : frc::TimedRobot(5_ms) {
     std::exit(-1);
   }
 #ifdef INTEGRATION
+  frc::SmartDashboard::PutBoolean("SysIdRun", false);
   // TODO use std::exit or EndCompetition once CTRE bug is fixed
   std::set_terminate([]() { std::_Exit(0); });
 #endif
@@ -123,6 +125,12 @@ void Robot::DisabledInit() {
 
 void Robot::SimulationPeriodic() {
 #ifdef INTEGRATION
+
+  bool enable = frc::SmartDashboard::GetBoolean("SysIdRun", false);
+  frc::sim::DriverStationSim::SetAutonomous(enable);
+  frc::sim::DriverStationSim::SetEnabled(enable);
+  frc::sim::DriverStationSim::NotifyNewData();
+
   if (frc::SmartDashboard::GetBoolean("SysIdKill", false)) {
     // TODO use std::exit or EndCompetition once CTRE bug is fixed
     std::terminate();


### PR DESCRIPTION
This PR will not collect data for faulty projects and the telemetry manager will display a popup notifying the user that they used the wrong project.

Fixes #177 