### PR TITLE
Clean up Eigen usage

### DIFF
--- a/sysid-application/src/main/native/cpp/analysis/ElevatorSim.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/ElevatorSim.cpp
@@ -11,17 +11,17 @@
 using namespace sysid;
 
 ElevatorSim::ElevatorSim(double Ks, double Kv, double Ka, double Kg,
-                         double initialPosition, double initialVelocity) {
-  // dx/dt = Ax + Bu + c sgn(x) + d
+                         double initialPosition, double initialVelocity)
+    // dx/dt = Ax + Bu + c sgn(x) + d
+    : m_A{{0.0, 1.0}, {0.0, -Kv / Ka}},
+      m_B{0.0, 1.0 / Ka},
+      m_c{0.0, -Ks / Ka},
+      m_d{0.0, -Kg / Ka} {
   Reset(initialPosition, initialVelocity);
-  m_A << 0.0, 1.0, 0.0, -Kv / Ka;
-  m_B << 0.0, 1.0 / Ka;
-  m_c << 0.0, -Ks / Ka;
-  m_d << 0.0, -Kg / Ka;
 }
 
 void ElevatorSim::Update(units::volt_t voltage, units::second_t dt) {
-  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  Eigen::Vector<double, 1> u{voltage.to<double>()};
 
   // Given dx/dt = Ax + Bu + c sgn(x) + d,
   // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c sgn(x) + d)
@@ -41,10 +41,10 @@ double ElevatorSim::GetVelocity() const {
 }
 
 double ElevatorSim::GetAcceleration(units::volt_t voltage) const {
-  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  Eigen::Vector<double, 1> u{voltage.to<double>()};
   return (m_A * m_x + m_B * u + m_c * wpi::sgn(GetVelocity()) + m_d)(1);
 }
 
 void ElevatorSim::Reset(double position, double velocity) {
-  m_x << position, velocity;
+  m_x = Eigen::Vector<double, 2>{position, velocity};
 }

--- a/sysid-application/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/FeedbackAnalysis.cpp
@@ -42,8 +42,8 @@ FeedbackGains sysid::CalculatePositionFeedbackGains(
 
   // This is our special model to avoid instabilities in the LQR.
   auto system = frc::LinearSystem<1, 1, 1>(
-      frc::MakeMatrix<1, 1>(0.0), frc::MakeMatrix<1, 1>(1.0),
-      frc::MakeMatrix<1, 1>(1.0), frc::MakeMatrix<1, 1>(0.0));
+      Eigen::Matrix<double, 1, 1>{0.0}, Eigen::Matrix<double, 1, 1>{1.0},
+      Eigen::Matrix<double, 1, 1>{1.0}, Eigen::Matrix<double, 1, 1>{0.0});
   // Create an LQR with one state -- position.
   frc::LinearQuadraticRegulator<1, 1> controller{
       system, {params.qp}, {params.r}, preset.period};

--- a/sysid-application/src/main/native/cpp/analysis/SimpleMotorSim.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/SimpleMotorSim.cpp
@@ -11,16 +11,14 @@
 using namespace sysid;
 
 SimpleMotorSim::SimpleMotorSim(double Ks, double Kv, double Ka,
-                               double initialPosition, double initialVelocity) {
-  // dx/dt = Ax + Bu + c sgn(x)
+                               double initialPosition, double initialVelocity)
+    // dx/dt = Ax + Bu + c sgn(x)
+    : m_A{{0.0, 1.0}, {0.0, -Kv / Ka}}, m_B{0.0, 1.0 / Ka}, m_c{0.0, -Ks / Ka} {
   Reset(initialPosition, initialVelocity);
-  m_A << 0.0, 1.0, 0.0, -Kv / Ka;
-  m_B << 0.0, 1.0 / Ka;
-  m_c << 0.0, -Ks / Ka;
 }
 
 void SimpleMotorSim::Update(units::volt_t voltage, units::second_t dt) {
-  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  Eigen::Vector<double, 1> u{voltage.to<double>()};
 
   // Given dx/dt = Ax + Bu + c sgn(x),
   // x_k+1 = e^(AT) x_k + A^-1 (e^(AT) - 1) (Bu + c sgn(x))
@@ -40,10 +38,10 @@ double SimpleMotorSim::GetVelocity() const {
 }
 
 double SimpleMotorSim::GetAcceleration(units::volt_t voltage) const {
-  auto u = frc::MakeMatrix<1, 1>(voltage.to<double>());
+  Eigen::Vector<double, 1> u{voltage.to<double>()};
   return (m_A * m_x + m_B * u + m_c * wpi::sgn(GetVelocity()))(1);
 }
 
 void SimpleMotorSim::Reset(double position, double velocity) {
-  m_x << position, velocity;
+  m_x = Eigen::Vector<double, 2>{position, velocity};
 }

--- a/sysid-application/src/main/native/include/sysid/analysis/AngularDriveSim.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AngularDriveSim.h
@@ -58,8 +58,8 @@ class AngularDriveSim {
  private:
   Eigen::Matrix<double, 2, 2> m_A;
   Eigen::Matrix<double, 2, 1> m_B;
-  Eigen::Matrix<double, 2, 1> m_c;
-  Eigen::Matrix<double, 2, 1> m_x;
+  Eigen::Vector<double, 2> m_c;
+  Eigen::Vector<double, 2> m_x;
   double m_trackwidth;
 };
 

--- a/sysid-application/src/main/native/include/sysid/analysis/ArmSim.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/ArmSim.h
@@ -55,9 +55,9 @@ class ArmSim {
  private:
   Eigen::Matrix<double, 1, 1> m_A;
   Eigen::Matrix<double, 1, 1> m_B;
-  Eigen::Matrix<double, 1, 1> m_c;
-  Eigen::Matrix<double, 1, 1> m_d;
-  Eigen::Matrix<double, 2, 1> m_x;
+  Eigen::Vector<double, 1> m_c;
+  Eigen::Vector<double, 1> m_d;
+  Eigen::Vector<double, 2> m_x;
 };
 
 }  // namespace sysid

--- a/sysid-application/src/main/native/include/sysid/analysis/ElevatorSim.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/ElevatorSim.h
@@ -55,9 +55,9 @@ class ElevatorSim {
  private:
   Eigen::Matrix<double, 2, 2> m_A;
   Eigen::Matrix<double, 2, 1> m_B;
-  Eigen::Matrix<double, 2, 1> m_c;
-  Eigen::Matrix<double, 2, 1> m_d;
-  Eigen::Matrix<double, 2, 1> m_x;
+  Eigen::Vector<double, 2> m_c;
+  Eigen::Vector<double, 2> m_d;
+  Eigen::Vector<double, 2> m_x;
 };
 
 }  // namespace sysid

--- a/sysid-application/src/main/native/include/sysid/analysis/SimpleMotorSim.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/SimpleMotorSim.h
@@ -54,8 +54,8 @@ class SimpleMotorSim {
  private:
   Eigen::Matrix<double, 2, 2> m_A;
   Eigen::Matrix<double, 2, 1> m_B;
-  Eigen::Matrix<double, 2, 1> m_c;
-  Eigen::Matrix<double, 2, 1> m_x;
+  Eigen::Vector<double, 2> m_c;
+  Eigen::Vector<double, 2> m_x;
 };
 
 }  // namespace sysid


### PR DESCRIPTION
* Replace Matrix<> with Vector<> where vectors are explicitly intended.
  I found these via `rg "Eigen::Matrix<double, \w+, 1>"`.
* Replace MakeMatrix() and operator<< usage with initializer list
  constructors. I found these via `rg MakeMatrix` and `rg "<<"`
  respectively.