### PR TITLE
Fix general mechanism config loading

### DIFF
--- a/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
+++ b/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
@@ -46,18 +46,18 @@ wpi::StringMap<wpi::SmallVector<std::string_view, 2>>
 };
 
 const wpi::SmallVector<std::string_view, 4> kPigeonCtors{"0", "WPI_TalonSRX-1"};
-const wpi::SmallVector<std::string_view, 4> kAnalogCtors{"0"};
+const wpi::SmallVector<std::string_view, 4> kAnalogGyroCtors{"0"};
 const wpi::SmallVector<std::string_view, 4> kNavXCtors{
     "SerialPort.kUSB", "I2C", "SerialPort.kMXP", "SPI.kMXP"};
 const wpi::SmallVector<std::string_view, 4> kADXRS450Ctors{"SPI.kMXP",
                                                            "kOnboardCS0"};
 wpi::StringMap<wpi::SmallVector<std::string_view, 4>> gyroCtorMap = {
-    {"AnalogGyro", kAnalogCtors},
+    {"AnalogGyro", kAnalogGyroCtors},
     // {"Pigeon", kPigeonCtors},
     // {"ADXRS450", kADXRS450Ctors},
     // FIXME: Waiting on Linux and macOS builds for navX AHRS
     // {"NavX", kNavXCtors},
-    {"None", kAnalogCtors}};
+    {"None", kAnalogGyroCtors}};
 
 class GenerationTest : public ::testing::Test {
  public:

--- a/sysid-application/src/main/native/include/sysid/view/Generator.h
+++ b/sysid-application/src/main/native/include/sysid/view/Generator.h
@@ -43,8 +43,8 @@ static constexpr std::array<const char*, 1> kBuiltInEncoders = {"Built-in"};
 static constexpr std::array<const char*, 2> kSparkMaxEncoders = {"Encoder Port",
                                                                  "Data Port"};
 
-static constexpr const char* kGyros[] = {"Analog", "ADXRS450", "NavX", "Pigeon",
-                                         "None"};
+static constexpr const char* kGyros[] = {"AnalogGyro", "ADXRS450", "NavX",
+                                         "Pigeon", "None"};
 static constexpr const char* kNavXCtors[] = {"SerialPort.kUSB", "I2C",
                                              "SerialPort.kMXP", "SPI.kMXP"};
 


### PR DESCRIPTION
The gyro type is saved as "AnalogGyro", but the arrays used for config
loading expect "Analog".