### PR TITLE
Refactor hardware device names to not use strings

### DIFF
--- a/sysid-application/src/main/native/cpp/generation/HardwareType.cpp
+++ b/sysid-application/src/main/native/cpp/generation/HardwareType.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "sysid/generation/HardwareType.h"
+
+#include <exception>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+using namespace sysid;
+
+HardwareType sysid::motorcontroller::FromMotorControllerName(
+    std::string_view name) {
+  if (name == "PWM") {
+    return sysid::motorcontroller::kPWM;
+  }
+  if (name == "TalonSRX") {
+    return sysid::motorcontroller::kTalonSRX;
+  }
+  if (name == "VictorSPX") {
+    return sysid::motorcontroller::kVictorSPX;
+  }
+  if (name == "TalonFX") {
+    return sysid::motorcontroller::kTalonFX;
+  }
+  if (name == "SPARK MAX (Brushless)") {
+    return sysid::motorcontroller::kSPARKMAXBrushless;
+  }
+  if (name == "SPARK MAX (Brushed)") {
+    return sysid::motorcontroller::kSPARKMAXBrushed;
+  }
+  if (name == "Venom") {
+    return sysid::motorcontroller::kVenom;
+  }
+  throw std::runtime_error(
+      fmt::format("Unsupported Motor Controller Name: {}", name));
+}
+
+HardwareType sysid::encoder::FromEncoderName(std::string_view name) {
+  if (name == "roboRIO quadrature") {
+    return sysid::encoder::kRoboRIO;
+  }
+  if (name == "CANCoder") {
+    return sysid::encoder::kCANCoder;
+  }
+  if (name == "Built-in") {
+    return sysid::encoder::kBuiltInSetting;
+  }
+  if (name == "Tachometer") {
+    return sysid::encoder::kCTRETachometer;
+  }
+  if (name == "Encoder Port") {
+    return sysid::encoder::kSMaxEncoderPort;
+  }
+  if (name == "Data Port") {
+    return sysid::encoder::kSMaxDataPort;
+  }
+  throw std::runtime_error(fmt::format("Unsupported Encoder Name: {}", name));
+}
+
+HardwareType sysid::gyro::FromGyroName(std::string_view name) {
+  if (name == "Analog Gyro") {
+    return sysid::gyro::kAnalogGyro;
+  }
+  if (name == "ADXRS450") {
+    return sysid::gyro::kADXRS450;
+  }
+  if (name == "NavX") {
+    return sysid::gyro::kNavX;
+  }
+  if (name == "Pigeon") {
+    return sysid::gyro::kPigeon;
+  }
+
+  if (name == "Romi") {
+    return sysid::gyro::kRomiGyro;
+  }
+
+  if (name == "None") {
+    return sysid::gyro::kNoGyroOption;
+  }
+  throw std::runtime_error(fmt::format("Unsupported Gyro Name: {}", name));
+}

--- a/sysid-application/src/main/native/include/sysid/generation/ConfigManager.h
+++ b/sysid-application/src/main/native/include/sysid/generation/ConfigManager.h
@@ -14,6 +14,8 @@
 #include <wpi/SmallVector.h>
 #include <wpi/json.h>
 
+#include "sysid/generation/HardwareType.h"
+
 namespace sysid {
 /**
  * This represents the settings for configuring a robot project -- including
@@ -26,14 +28,15 @@ struct ConfigSettings {
   wpi::SmallVector<int, 3> secondaryMotorPorts = {2, 3};
 
   // Type of motor controller.
-  wpi::SmallVector<std::string, 3> motorControllers = {"PWM", "PWM"};
+  wpi::SmallVector<HardwareType, 3> motorControllers = {
+      sysid::motorcontroller::kPWM, sysid::motorcontroller::kPWM};
 
   // Whether motors should be inverted.
   wpi::SmallVector<bool, 3> primaryMotorsInverted = {false, false};
   wpi::SmallVector<bool, 3> secondaryMotorsInverted = {false, false};
 
   // Encoder type and ports.
-  std::string encoderType = "roboRIO";
+  HardwareType encoderType = sysid::encoder::kRoboRIO;
   std::array<int, 2> primaryEncoderPorts = {0, 1};
   std::array<int, 2> secondaryEncoderPorts = {2, 3};
 
@@ -46,7 +49,7 @@ struct ConfigSettings {
   double gearing = 1.0;
 
   // Gyro type and constructor.
-  std::string gyro = "AnalogGyro";
+  HardwareType gyro = sysid::gyro::kAnalogGyro;
   std::string gyroCtor = "0";
 
   // Advanced encoder settings.
@@ -59,9 +62,20 @@ struct ConfigSettings {
 };
 
 // Pre-built configuration for the Romi -- all Romis have the same setup.
-const ConfigSettings kRomiConfig{{0},       {1},    {"PWM"}, {true}, {false},
-                                 "roboRIO", {4, 5}, {6, 7},  false,  false,
-                                 1440.0,    1.0,    "Romi",  ""};
+const ConfigSettings kRomiConfig{{0},
+                                 {1},
+                                 {sysid::motorcontroller::kPWM},
+                                 {true},
+                                 {false},
+                                 sysid::encoder::kRoboRIO,
+                                 {4, 5},
+                                 {6, 7},
+                                 false,
+                                 false,
+                                 1440.0,
+                                 1.0,
+                                 sysid::gyro::kRomiGyro,
+                                 ""};
 
 /**
  * This class manages generating the JSON configuration from a reference to the

--- a/sysid-application/src/main/native/include/sysid/generation/HardwareType.h
+++ b/sysid-application/src/main/native/include/sysid/generation/HardwareType.h
@@ -1,0 +1,103 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace sysid {
+struct HardwareType {
+  /**
+   * The name of the hardware device to facillitate comparisons
+   */
+  std::string_view name;
+
+  /**
+   * The display name of the hardware device to facilitate GUI display
+   */
+  const char* displayName;
+
+  constexpr explicit HardwareType(std::string_view deviceName)
+      : name{deviceName}, displayName{name.data()} {}
+
+  constexpr bool operator==(const HardwareType& rhs) const {
+    return name == rhs.name;
+  }
+  constexpr bool operator!=(const HardwareType& rhs) const {
+    return !operator==(rhs);
+  }
+};
+
+namespace motorcontroller {
+
+constexpr HardwareType kPWM{"PWM"};
+constexpr HardwareType kTalonSRX{"TalonSRX"};
+constexpr HardwareType kVictorSPX{"VictorSPX"};
+constexpr HardwareType kTalonFX{"TalonFX"};
+constexpr HardwareType kSPARKMAXBrushless{"SPARK MAX (Brushless)"};
+constexpr HardwareType kSPARKMAXBrushed{"SPARK MAX (Brushed)"};
+constexpr HardwareType kVenom{"Venom"};
+
+constexpr std::array<HardwareType, 7> kMotorControllers = {
+    kPWM,     kTalonSRX,          kVictorSPX,
+    kTalonFX, kSPARKMAXBrushless, kSPARKMAXBrushed,
+    kVenom};
+
+/**
+ * Returns an existing motor controller HardwareType from a string_view. Throws
+ * if the passed name doesn't exist.
+ *
+ * @param name The name of the motor controller.
+ *
+ * @return The motor controller HardwareType associated with the inputted name.
+ */
+HardwareType FromMotorControllerName(std::string_view name);
+}  // namespace motorcontroller
+
+namespace encoder {
+constexpr HardwareType kRoboRIO{"roboRIO quadrature"};
+constexpr HardwareType kCANCoder{"CANCoder"};
+constexpr HardwareType kBuiltInSetting{"Built-in"};
+constexpr HardwareType kCTRETachometer{"Tachometer"};
+constexpr HardwareType kSMaxEncoderPort{"Encoder Port"};
+constexpr HardwareType kSMaxDataPort{"Data Port"};
+
+constexpr std::array<HardwareType, 6> kEncoders = {
+    kRoboRIO,        kCANCoder,        kBuiltInSetting,
+    kCTRETachometer, kSMaxEncoderPort, kSMaxDataPort};
+
+/**
+ * Returns an existing encoder HardwareType from a string_view. Throws if the
+ * passed name doesn't exist.
+ *
+ * @param name The name of the encoder.
+ *
+ * @return The encoder HardwareType associated with the inputted name.
+ */
+HardwareType FromEncoderName(std::string_view name);
+}  // namespace encoder
+
+namespace gyro {
+constexpr HardwareType kAnalogGyro{"Analog Gyro"};
+constexpr HardwareType kADXRS450{"ADXRS450"};
+constexpr HardwareType kNavX{"NavX"};
+constexpr HardwareType kPigeon{"Pigeon"};
+constexpr HardwareType kRomiGyro{"Romi"};
+constexpr HardwareType kNoGyroOption{"None"};
+
+constexpr std::array<HardwareType, 6> kGyros = {
+    kAnalogGyro, kADXRS450, kNavX, kPigeon, kRomiGyro, kNoGyroOption};
+
+/**
+ * Returns an existing gyro HardwareType from a string_view. Throws if the
+ * passed name doesn't exist.
+ *
+ * @param name The name of the gyro.
+ *
+ * @return The gyro HardwareType associated with the inputted name.
+ */
+HardwareType FromGyroName(std::string_view name);
+}  // namespace gyro
+}  // namespace sysid

--- a/sysid-application/src/test/native/cpp/generation/HardwareTypeTest.cpp
+++ b/sysid-application/src/test/native/cpp/generation/HardwareTypeTest.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <functional>
+#include <stdexcept>
+#include <string_view>
+
+#include <wpi/StringMap.h>
+
+#include "gtest/gtest.h"
+#include "sysid/generation/HardwareType.h"
+
+/**
+ * Tests to see if a HardwareType conversion function works on a given test
+ * array. It iterates through the test array and sees if the function returns
+ * the right HardwareType when given the string associated with said
+ * HardwareType.
+ *
+ * @tparam S The size of the test array
+ *
+ * @param testArray The test array of HardwareTypes
+ * @param func The function that should return the corresponding HardwareType
+ *             based off of a passed string
+ */
+template <size_t S>
+static void TestConversionFunction(
+    std::array<sysid::HardwareType, S> testArray,
+    std::function<sysid::HardwareType(std::string_view)> func) {
+  for (auto& it : testArray) {
+    auto hardwareType = func(it.name);
+    EXPECT_EQ(hardwareType, it);
+  }
+}
+
+TEST(HardwareTypeTest, FromMotorControllerName) {
+  TestConversionFunction(sysid::motorcontroller::kMotorControllers,
+                         sysid::motorcontroller::FromMotorControllerName);
+  EXPECT_THROW(sysid::motorcontroller::FromMotorControllerName(""),
+               std::runtime_error);
+}
+
+TEST(HardwareTypeTest, FromEncoderName) {
+  TestConversionFunction(sysid::encoder::kEncoders,
+                         sysid::encoder::FromEncoderName);
+  EXPECT_THROW(sysid::encoder::FromEncoderName(""), std::runtime_error);
+}
+
+TEST(HardwareTypeTest, FromGyroName) {
+  TestConversionFunction(sysid::gyro::kGyros, sysid::gyro::FromGyroName);
+  EXPECT_THROW(sysid::gyro::FromGyroName(""), std::runtime_error);
+}


### PR DESCRIPTION
Fixes #210  and resolves #208 

Fixes a bug mentioned in #208  where the wrong encoder is loaded from config files due to the [GUI automatically resetting](https://github.com/wpilibsuite/sysid/pull/189/files#diff-4db26c65af78f49cb0a7385146e99aa2e25dcc97f6c52196d72c8bd8d5dff015R315-R321) the encoder selection upon detecting a change in motor controller selection:
(`Generator::UpdateFromConfig()` function)
```
 // Set Previous Main Controller to current to not reset encoder selection
  m_prevMainMotorController = mainMotorController;
 ```