### PR TITLE
Remove unnecessary analysis project print

### DIFF
--- a/sysid-projects/analysis-test/src/main/cpp/Drivetrain.cpp
+++ b/sysid-projects/analysis-test/src/main/cpp/Drivetrain.cpp
@@ -4,7 +4,6 @@
 
 #include "Drivetrain.h"
 
-#include <fmt/format.h>
 #include <frc/RobotController.h>
 
 void Drivetrain::SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds) {
@@ -47,8 +46,6 @@ void Drivetrain::SimulationPeriodic() {
                                   units::volt_t{m_rightLeader.Get()} *
                                       frc::RobotController::GetInputVoltage());
   m_drivetrainSimulator.Update(5_ms);
-
-  fmt::print("{}\n", m_drivetrainSimulator.GetLeftPosition().value());
 
   m_leftEncoderSim.SetDistance(m_drivetrainSimulator.GetLeftPosition().value());
   m_leftEncoderSim.SetRate(m_drivetrainSimulator.GetLeftVelocity().value());


### PR DESCRIPTION
This print pollutes the console whenever the analysis integration test is run, making it difficult to see what's going on.