### PR TITLE
Fix windows generation test issue

### DIFF
--- a/sysid-application/src/integrationtest-utils/native/include/IntegrationUtils.h
+++ b/sysid-application/src/integrationtest-utils/native/include/IntegrationUtils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include <string_view>
 
 #include <ntcore_c.h>
@@ -36,8 +37,10 @@ void Connect(NT_Inst nt, NT_Entry kill);
  * the robot code. This assumes that the simulated code uses a NT kill entry to
  * end the simulation.
  *
- * @param nt the Network Tables Intstance
+ * @param nt the Network Tables Instance
  * @param kill the Network Tables Entry responsible for killing the simulated
- * code.
+ *             code.
+ *
+ * @return captured console output during the robot simulation.
  */
-void KillNT(NT_Inst nt, NT_Entry kill);
+std::string KillNT(NT_Inst nt, NT_Entry kill);

--- a/sysid-projects/drive/src/main/cpp/Robot.cpp
+++ b/sysid-projects/drive/src/main/cpp/Robot.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <exception>
+#include <iostream>
 #include <string>
 #include <string_view>
 
@@ -208,6 +209,7 @@ Robot::Robot() : frc::TimedRobot(5_ms) {
     std::exit(-1);
   }
   m_logger.UpdateThreadPriority();
+  std::cout.flush();
 
 #ifdef INTEGRATION
   frc::SmartDashboard::PutBoolean("SysIdRun", false);

--- a/sysid-projects/mechanism/src/main/cpp/Robot.cpp
+++ b/sysid-projects/mechanism/src/main/cpp/Robot.cpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <exception>
+#include <iostream>
 #include <string>
 
 #include <fmt/format.h>
@@ -58,6 +59,7 @@ Robot::Robot() : frc::TimedRobot(5_ms) {
     fmt::print("Project failed: {}\n", e.what());
     std::exit(-1);
   }
+  std::cout.flush();
 #ifdef INTEGRATION
   frc::SmartDashboard::PutBoolean("SysIdRun", false);
   // TODO use std::exit or EndCompetition once CTRE bug is fixed


### PR DESCRIPTION
Fixes #223 by starting console output capture right before the simulation window is launched and ending it before it's closed which seems to fix the issue of the process hanging afterwards.