### PR TITLE
Add captured output prints into integration tests

### DIFF
--- a/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
+++ b/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
@@ -89,7 +89,8 @@ class GenerationTest : public ::testing::Test {
 
     // Prints out stored output to help with debugging
     if (!found) {
-      fmt::print(stderr, "{}\n", m_logContent);
+      fmt::print(stderr, "******\nOutput Searched Through:\n{}\n******\n",
+                 m_logContent);
     }
   }
 

--- a/sysid-application/src/integrationtest-utils/native/cpp/IntegrationUtils.cpp
+++ b/sysid-application/src/integrationtest-utils/native/cpp/IntegrationUtils.cpp
@@ -58,6 +58,10 @@ void Connect(NT_Inst nt, NT_Entry kill) {
   while (!nt::IsConnected(nt)) {
     if (wpi::Now() - time > 1.5E7) {
       fmt::print(stderr, "The robot program crashed\n");
+      auto capturedStdout = ::testing::internal::GetCapturedStdout();
+      fmt::print(stderr,
+                 "\n******\nRobot Program Captured Output:\n{}\n******\n",
+                 capturedStdout);
       std::exit(1);
     }
   }


### PR DESCRIPTION
Helps with debugging whenever an integration test crashes or fails.