### PR TITLE
Give deployed shared libraries proper ownership and permissions

### DIFF
--- a/sysid-application/src/main/native/cpp/deploy/DeploySession.cpp
+++ b/sysid-application/src/main/native/cpp/deploy/DeploySession.cpp
@@ -158,6 +158,9 @@ void DeploySession::Execute(wpi::uv::Loop& lp) {
                 "chmod -R 777 /home/lvuser/deploy || true; chown -R lvuser:ni "
                 "/home/lvuser/deploy");
             session.Execute(
+                "chmod -R 777 /usr/local/frc/third-party/lib || true; chown -R "
+                "lvuser:ni /usr/local/frc/third-party/lib");
+            session.Execute(
                 "echo ' \"/home/lvuser/frcUserProgram\" ' > "
                 "/home/lvuser/robotCommand");
             session.Execute(


### PR DESCRIPTION
GradleRIO gives them 777 permissions and lvuser:ni ownership. The shared
libraries must be readable for frcUserProgram to be able to load them.