### PR TITLE
Upgrade to imgui 1.86 to match allwpilib

### DIFF
--- a/sysid-application/config/native.gradle
+++ b/sysid-application/config/native.gradle
@@ -9,7 +9,7 @@ nativeUtils.addWpiNativeUtils()
 nativeUtils.wpi.configureDependencies {
   wpiVersion = wpilibVersion
   wpimathVersion = wpilibVersion
-  imguiVersion = "1.85-2"
+  imguiVersion = "1.86-1"
   googleTestVersion = "1.9.0-5-437e100-1"
 }
 


### PR DESCRIPTION
SysId fails on startup on my machine otherwise:
```
sysid: /__w/thirdparty-imgui/thirdparty-imgui/imgui/imgui.cpp:7237: bool ImGui::DebugCheckVersionAndDataLayout(const char*, size_t, size_t, size_t, size_t, size_t, size_t): Assertion `strcmp(version, "1.85") == 0 && "Mismatched version string!"' failed.
```