### PR TITLE
Add Romi to drivetrain project

### DIFF
--- a/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
+++ b/sysid-application/src/integrationtest-generation/native/cpp/GenerationTest.cpp
@@ -283,10 +283,18 @@ TEST_F(GenerationTest, Drivetrain) {
     }
   }
 
-  // m_settings = sysid::kRomiConfig;
-  // m_manager.SaveJSON(m_jsonPath, 1, true);
-  // fmt::print(stderr, "Testing: Romi Config\n");
-  // Run();
+  m_settings = sysid::kRomiConfig;
+  auto json = m_manager.Generate(size);
+  sysid::SaveFile(json.dump(), m_jsonPath);
+  fmt::print(stderr, "Testing: Romi Config\n");
+  Run();
+  if (HasFatalFailure()) {
+    TearDown();
+    return;
+  }
+  TestHardwareConfig(m_settings.motorControllers[0].name,
+                     m_settings.encoderType.name, m_settings.gyro.name,
+                     m_settings.gyroCtor);
 }
 
 TEST_F(GenerationTest, WrongMechDrivetrain) {

--- a/sysid-library/src/main/cpp/generation/SysIdSetup.cpp
+++ b/sysid-library/src/main/cpp/generation/SysIdSetup.cpp
@@ -13,6 +13,7 @@
 #include <frc/Filesystem.h>
 #include <frc/TimedRobot.h>
 #include <frc/motorcontrol/Spark.h>
+#include <frc/romi/RomiGyro.h>
 #include <units/angle.h>
 #include <units/angular_velocity.h>
 #include <wpi/SmallString.h>
@@ -373,7 +374,9 @@ void SetupGyro(
       //     // FIXME: Update Romi Gyro once vendordep is out
     } else if (gyroType == "Romi") {
       fmt::print("Setup Romi");
-      // gyro = std::make_unique<frc::RomiGyro>();
+#ifndef __FRC_ROBORIO__
+      gyro = std::make_unique<frc::RomiGyro>();
+#endif
     } else {
       try {
         fmt::print("Setup Analog Gyro, Port: {}", gyroCtor);

--- a/sysid-projects/drive/src/main/cpp/Robot.cpp
+++ b/sysid-projects/drive/src/main/cpp/Robot.cpp
@@ -14,7 +14,6 @@
 #include <fmt/format.h>
 #include <frc/ADXRS450_Gyro.h>
 #include <frc/AnalogGyro.h>
-// #include <frc/romi/RomiGyro.h>
 #include <frc/simulation/DriverStationSim.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <wpi/StringExtras.h>

--- a/vendordeps/RomiVendordep.json
+++ b/vendordeps/RomiVendordep.json
@@ -1,0 +1,36 @@
+{
+  "fileName": "RomiVendordep.json",
+  "name": "Romi-Vendordep",
+  "version": "2022.1.1-beta-4",
+  "uuid": "2854af28-a682-4c3e-abe5-1f62c288c6b8",
+  "mavenUrls": [],
+  "jsonUrl": "",
+  "javaDependencies": [
+      {
+          "groupId": "edu.wpi.first.romi",
+          "artifactId": "romi-vendordep-java",
+          "version": "2022.1.1-beta-4"
+      }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+      {
+          "groupId": "edu.wpi.first.romi",
+          "artifactId": "romi-vendordep-cpp",
+          "version": "2022.1.1-beta-4",
+          "libName": "romiVendordep",
+          "headerClassifier": "headers",
+          "sourcesClassifier": "sources",
+          "sharedLibrary": true,
+          "skipInvalidPlatforms": true,
+          "binaryPlatforms": [
+              "linuxraspbian",
+              "linuxaarch64bionic",
+              "windowsx86-64",
+              "windowsx86",
+              "linuxx86-64",
+              "osxx86-64"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
This doesn't deploy the simgui so the romi isn't fully supported but its a part of the project and also included in the integration tests.

Fixes #114 