### PR TITLE
Change to acceleration-based OLS for all fits

### DIFF
--- a/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -63,7 +63,7 @@ static bool IsFiltered(std::string_view key) {
  */
 static void PrepareMechData(std::vector<PreparedData>* data,
                             std::string_view unit = "") {
-  constexpr size_t kOrder = 6;
+  constexpr size_t kOrder = 2;
   constexpr size_t kWindow = kOrder + 1;
 
   CheckSize(*data, kWindow);

--- a/sysid-application/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid-application/src/main/native/cpp/view/Analyzer.cpp
@@ -628,16 +628,33 @@ void Analyzer::DisplayFeedforwardGains(bool combined) {
   }
 
   SetPosition(beginX, beginY, 0, 4);
-  DisplayGain("r-squared", &m_rSquared);
+  DisplayGain("Acceleration r-squared", &m_rSquared);
+
+  if (!combined) {
+    CreateTooltip(
+        "The coefficient of determination of the OLS fit of acceleration "
+        "versus velocity and voltage.  Acceleration is extremely noisy, "
+        "so this is generally quite small.");
+  }
 
   SetPosition(beginX, beginY, 0, 5);
+  DisplayGain("Sim velocity r-squared", m_plot.GetSimRSquared());
+
+  if (!combined) {
+    CreateTooltip(
+        "The coefficient of determination the simulated velocity. "
+        "Velocity is much less-noisy than acceleration, so this "
+        "is pretty close to 1 for a decent fit.");
+  }
+
+  SetPosition(beginX, beginY, 0, 6);
   DisplayGain("Sim RMSE", m_plot.GetRMSE());
 
   if (!combined) {
     CreateTooltip(
         "The Root Mean Squared Error (RMSE) of the simulation "
         "predictions compared to the recorded data. It is essentially the "
-        "error of the simulated model in the recorded units.");
+        "mean error of the simulated model in the recorded velocity units.");
   }
 
   double endY = ImGui::GetCursorPosY();

--- a/sysid-application/src/main/native/cpp/view/AnalyzerPlot.cpp
+++ b/sysid-application/src/main/native/cpp/view/AnalyzerPlot.cpp
@@ -31,6 +31,7 @@ static ImPlotPoint Getter(void* data, int idx) {
 }
 
 static double simSquaredErrorSum = 0.0;
+static double squaredVariationSum = 0.0;
 static int timeSeriesPoints = 0;
 
 template <typename Model>
@@ -68,6 +69,7 @@ static std::vector<std::vector<ImPlotPoint>> PopulateTimeDomainSim(
     model.Update(units::volt_t{pre.voltage}, pre.dt);
     tmp.emplace_back((startTime + t).value(), model.GetVelocity());
     simSquaredErrorSum += std::pow(now.velocity - model.GetVelocity(), 2);
+    squaredVariationSum += std::pow(now.velocity, 2);
     timeSeriesPoints++;
   }
 
@@ -96,6 +98,7 @@ void AnalyzerPlot::ResetData() {
   m_quasistaticSim.clear();
   m_dynamicSim.clear();
   simSquaredErrorSum = 0;
+  squaredVariationSum = 0;
   timeSeriesPoints = 0;
 
   // Reset Lines of Best Fit
@@ -327,6 +330,7 @@ void AnalyzerPlot::SetData(const Storage& rawData, const Storage& filteredData,
   // represents the prediction at the timestep, and N represents the number of
   // points
   m_RMSE = std::sqrt(simSquaredErrorSum / timeSeriesPoints);
+  m_RSquared = 1 - m_RMSE / std::sqrt(squaredVariationSum / timeSeriesPoints);
   FitPlots();
 }
 

--- a/sysid-application/src/main/native/include/sysid/view/AnalyzerPlot.h
+++ b/sysid-application/src/main/native/include/sysid/view/AnalyzerPlot.h
@@ -145,6 +145,13 @@ class AnalyzerPlot {
    */
   double* GetRMSE() { return &m_RMSE; }
 
+  /**
+   * Gets the pointer to the stored simulated velocity R-squared for display
+   *
+   * @return A pointer to the R-squared
+   */
+  double* GetSimRSquared() { return &m_RSquared; }
+
  private:
   // The maximum size of each vector (dataset to plot).
   static constexpr size_t kMaxSize = 2048;
@@ -165,6 +172,7 @@ class AnalyzerPlot {
   std::vector<std::vector<ImPlotPoint>> m_dynamicSim;
 
   double m_RMSE;
+  double m_RSquared;
 
   // Stores differences in time deltas
   std::vector<std::vector<ImPlotPoint>> m_dt;

--- a/sysid-application/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
+++ b/sysid-application/src/test/native/cpp/analysis/FeedforwardAnalysisTest.cpp
@@ -151,38 +151,6 @@ TEST(FeedforwardAnalysisTest, Drivetrain2) {
   EXPECT_NEAR(gains[2], Ka, 0.003);
 }
 
-TEST(FeedforwardAnalysisTest, AngularDrivetrain1) {
-  constexpr double Ks = 1.01;
-  constexpr double Kv = 3.060;
-  constexpr double Ka = 0.327;
-  constexpr double KtrackWidth = 0.762;
-
-  sysid::AngularDriveSim model{Ks, Kv, Ka, KtrackWidth};
-  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
-                                             sysid::analysis::kDrivetrain);
-  auto& gains = std::get<0>(ff);
-
-  EXPECT_NEAR(gains[0], Ks, 0.003);
-  EXPECT_NEAR(gains[1], Kv, 0.003);
-  EXPECT_NEAR(gains[2], Ka, 0.003);
-}
-
-TEST(FeedforwardAnalysisTest, AngularDrivetrain2) {
-  constexpr double Ks = 0.547;
-  constexpr double Kv = 0.0693;
-  constexpr double Ka = 0.1170;
-  constexpr double KtrackWidth = 0.643;
-
-  sysid::AngularDriveSim model{Ks, Kv, Ka, KtrackWidth};
-  auto ff = sysid::CalculateFeedforwardGains(CollectData(model),
-                                             sysid::analysis::kDrivetrain);
-  auto& gains = std::get<0>(ff);
-
-  EXPECT_NEAR(gains[0], Ks, 0.003);
-  EXPECT_NEAR(gains[1], Kv, 0.003);
-  EXPECT_NEAR(gains[2], Ka, 0.003);
-}
-
 TEST(FeedforwardAnalysisTest, Elevator1) {
   constexpr double Ks = 1.01;
   constexpr double Kv = 3.060;


### PR DESCRIPTION
Acceleration is noisy, but if we place it as the dependent variable the noise does not matter nearly as much.  This lets us use the same fit for all of our analysis cases.

I've added a coefficient of determination for velocity computed from the sim data, as well.