### PR TITLE
Remove median filter

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid-application/src/main/native/cpp/view/Analyzer.cpp
@@ -671,25 +671,9 @@ void Analyzer::DisplayFeedforwardGains(bool combined) {
     SetPosition(beginX, beginY, horizontalSpacing, 1);
   }
 
-  // Wait for enter before refresh so double digit entries like "15" don't
-  // prematurely refresh with "1". That can cause display stuttering.
-  ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
-  int window = m_settings.windowSize;
-  if (ImGui::InputInt("Window Size", &window, 0, 0,
-                      combined ? ImGuiInputTextFlags_ReadOnly
-                               : ImGuiInputTextFlags_EnterReturnsTrue)) {
-    m_settings.windowSize = std::clamp(window, 2, 15);
-    m_enabled = true;
-    RefreshInformation();
-  }
-
-  CreateTooltip(
-      "The number of samples in the velocity median "
-      "filter's sliding window.");
-
   // Wait for enter before refresh so decimal inputs like "0.2" don't
   // prematurely refresh with a velocity threshold of "0".
-  SetPosition(beginX, beginY, horizontalSpacing, combined ? 1 : 2);
+  SetPosition(beginX, beginY, horizontalSpacing, 1);
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
   double threshold = m_settings.motionThreshold;
   if (ImGui::InputDouble("Velocity Threshold", &threshold, 0.0, 0.0, "%.3f",
@@ -702,7 +686,7 @@ void Analyzer::DisplayFeedforwardGains(bool combined) {
 
   CreateTooltip("Velocity data below this threshold will be ignored.");
 
-  SetPosition(beginX, beginY, horizontalSpacing, combined ? 2 : 3);
+  SetPosition(beginX, beginY, horizontalSpacing, 2);
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
   if (!combined) {
     if (ImGui::SliderFloat("Test Duration", &m_stepTestDuration,

--- a/sysid-application/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -31,17 +31,6 @@ namespace sysid {
 double GetAccelNoiseFloor(const std::vector<PreparedData>& data, int window);
 
 /**
- * Reduces noise in velocity data by applying a median filter.
- *
- * @tparam S The size of the raw data array
- * @tparam Velocity The index of the velocity entry in the raw data.
- * @param data the vector of arrays representing sysid data (must contain
- *             velocity data)
- * @param window the size of the window of the median filter (must be odd)
- */
-void ApplyMedianFilter(std::vector<PreparedData>* data, int window);
-
-/**
  * Trims the step voltage data to discard all points before the maximum
  * acceleration and after reaching stead-state velocity. Also trims the end of
  * the test based off of user specified test durations, but it will determine a

--- a/sysid-application/src/test/native/cpp/analysis/FilterTest.cpp
+++ b/sysid-application/src/test/native/cpp/analysis/FilterTest.cpp
@@ -12,24 +12,6 @@
 #include "sysid/analysis/FilteringUtils.h"
 #include "sysid/analysis/Storage.h"
 
-TEST(FilterTest, MedianFilter) {
-  std::vector<sysid::PreparedData> testData{
-      sysid::PreparedData{0_s, 0, 0, 0},    sysid::PreparedData{0_s, 0, 0, 1},
-      sysid::PreparedData{0_s, 0, 0, 10},   sysid::PreparedData{0_s, 0, 0, 5},
-      sysid::PreparedData{0_s, 0, 0, 3},    sysid::PreparedData{0_s, 0, 0, 0},
-      sysid::PreparedData{0_s, 0, 0, 1000}, sysid::PreparedData{0_s, 0, 0, 7},
-      sysid::PreparedData{0_s, 0, 0, 6},    sysid::PreparedData{0_s, 0, 0, 5}};
-  std::vector<sysid::PreparedData> expectedData{
-      sysid::PreparedData{0_s, 0, 0, 0}, sysid::PreparedData{0_s, 0, 0, 1},
-      sysid::PreparedData{0_s, 0, 0, 5}, sysid::PreparedData{0_s, 0, 0, 5},
-      sysid::PreparedData{0_s, 0, 0, 3}, sysid::PreparedData{0_s, 0, 0, 3},
-      sysid::PreparedData{0_s, 0, 0, 7}, sysid::PreparedData{0_s, 0, 0, 7},
-      sysid::PreparedData{0_s, 0, 0, 6}, sysid::PreparedData{0_s, 0, 0, 5}};
-
-  sysid::ApplyMedianFilter(&testData, 3);
-  EXPECT_EQ(expectedData, testData);
-}
-
 TEST(FilterTest, AccelNoiseFloor) {
   std::vector<sysid::PreparedData> testData = {
       {0_s, 1, 2, 3, 3, 5_ms, 0, 0},    {1_s, 1, 2, 3, 3, 5_ms, 1, 0},


### PR DESCRIPTION
Removes the median filter, as it no longer appreciably improves the quality of the fit on actual robot data (and in scenarios where it does, the sensor noise should probably be fixed anyway...)