### PR TITLE
Turn median filter off by default

### DIFF
--- a/sysid-application/src/integrationtest-analysis/native/cpp/AnalysisTest.cpp
+++ b/sysid-application/src/integrationtest-analysis/native/cpp/AnalysisTest.cpp
@@ -98,7 +98,7 @@ class AnalysisTest : public ::testing::Test {
     auto path = m_manager->SaveJSON(EXPAND_STRINGIZE(PROJECT_ROOT_DIR));
     try {
       auto analyzerSettings = sysid::AnalysisManager::Settings{};
-      analyzerSettings.windowSize = 13;
+      analyzerSettings.windowSize = 1;
       if (m_settings.mechanism == sysid::analysis::kArm) {
         analyzerSettings.motionThreshold = 0.01;  // Reduce threshold for arm
                                                   // test

--- a/sysid-application/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid-application/src/main/native/cpp/view/Analyzer.cpp
@@ -642,7 +642,7 @@ void Analyzer::DisplayFeedforwardGains(bool combined) {
   if (ImGui::InputInt("Window Size", &window, 0, 0,
                       combined ? ImGuiInputTextFlags_ReadOnly
                                : ImGuiInputTextFlags_EnterReturnsTrue)) {
-    m_settings.windowSize = std::clamp(window, 2, 15);
+    m_settings.windowSize = std::clamp(window, 1, 15);
     m_enabled = true;
     RefreshInformation();
   }

--- a/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -61,7 +61,7 @@ class AnalysisManager {
     /**
      * The window size for computing acceleration.
      */
-    int windowSize = 9;
+    int windowSize = 1;
 
     /**
      * The dataset that is being analyzed.


### PR DESCRIPTION
The acceleration OLS fit we use now is more robust to noise. Users can still increase the window size if they need it.