### PR TITLE
Add more robust analysis error handling

### DIFF
--- a/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -625,6 +625,14 @@ void AnalysisManager::PrepareData() {
 }
 
 AnalysisManager::Gains AnalysisManager::Calculate() {
+  if (m_filteredDatasets.empty()) {
+    throw std::runtime_error(
+        "There is an unresolved issue with the data being used. Please "
+        "double-check the data quality and adjust settings such as units, "
+        "velocity threshold, test duration, etc. to make sure that there are "
+        "no errors with the dataset before attempting to re-calculate gains.");
+  }
+
   WPI_INFO(m_logger, "{}", "Calculating Gains");
   // Calculate feedforward gains from the data.
   auto ffGains = sysid::CalculateFeedforwardGains(

--- a/sysid-application/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid-application/src/main/native/cpp/view/Analyzer.cpp
@@ -91,7 +91,7 @@ void Analyzer::Display() {
     if (ImGui::Combo("Dataset", &m_settings.dataset, AnalysisManager::kDatasets,
                      m_type == analysis::kDrivetrain ? 9 : 3)) {
       m_enabled = true;
-      Calculate();
+      RefreshInformation();
       PrepareGraphs();
     }
     ImGui::SameLine(width - ImGui::CalcTextSize("Reset").x);
@@ -151,24 +151,26 @@ void Analyzer::Display() {
         try {
           m_manager->OverrideUnits(m_unit, m_factor);
           m_enabled = true;
-          Calculate();
+          RefreshInformation();
         } catch (const std::exception& e) {
-          ex = true;
-          m_exception = e.what();
+          HandleGeneralError(e);
         }
       }
 
       ImGui::EndPopup();
-      if (ex) {
-        m_errorPopup = true;
-      }
     }
 
     ImGui::SameLine();
     if (ImGui::Button("Reset Units from JSON")) {
-      m_manager->ResetUnitsFromJSON();
-      m_enabled = true;
-      Calculate();
+      try {
+        m_manager->ResetUnitsFromJSON();
+        m_factor = m_manager->GetFactor();
+        m_unit = m_manager->GetUnit();
+        m_enabled = true;
+        RefreshInformation();
+      } catch (const std::exception& e) {
+        HandleGeneralError(e);
+      }
     }
   }
 


### PR DESCRIPTION
There is now repreparation of the data and exception handling if any part of the feedforward analyzer GUI section is updated.

For feedback calculations, an exception is now thrown if there isn't any data to calculate gains from. This error is subsequently handled in the GUI.

Fixes #340 (wrt the crashing issue)

