### PR TITLE
Compute default motion threshold

### DIFF
--- a/sysid-application/src/integrationtest-analysis/native/cpp/AnalysisTest.cpp
+++ b/sysid-application/src/integrationtest-analysis/native/cpp/AnalysisTest.cpp
@@ -98,11 +98,6 @@ class AnalysisTest : public ::testing::Test {
     auto path = m_manager->SaveJSON(EXPAND_STRINGIZE(PROJECT_ROOT_DIR));
     try {
       auto analyzerSettings = sysid::AnalysisManager::Settings{};
-      analyzerSettings.accelerationWindow = 13;
-      if (m_settings.mechanism == sysid::analysis::kArm) {
-        analyzerSettings.motionThreshold = 0.01;  // Reduce threshold for arm
-                                                  // test
-      }
       sysid::AnalysisManager analyzer{path, analyzerSettings, m_logger};
 
       analyzer.PrepareData();

--- a/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -217,8 +217,8 @@ static void PrepareGeneralData(
                 preparedData["original-raw-fast-backward"]);
 
   WPI_INFO(logger, "{}", "Initial trimming and filtering.");
-  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime, maxStepTime,
-                              unit);
+  sysid::InitialTrimAndFilter(&preparedData, &settings, minStepTime,
+                              maxStepTime, unit);
 
   WPI_INFO(logger, "{}", "Acceleration filtering.");
   sysid::AccelFilter(&preparedData);
@@ -360,7 +360,7 @@ static void PrepareAngularDrivetrainData(
                 preparedData["original-raw-fast-backward"]);
 
   WPI_INFO(logger, "{}", "Applying trimming and filtering.");
-  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime,
+  sysid::InitialTrimAndFilter(&preparedData, &settings, minStepTime,
                               maxStepTime);
 
   WPI_INFO(logger, "{}", "Acceleration filtering.");
@@ -498,7 +498,7 @@ static void PrepareLinearDrivetrainData(
                 originalFastBackwardRight, "Right");
 
   WPI_INFO(logger, "{}", "Applying trimming and filtering.");
-  sysid::InitialTrimAndFilter(&preparedData, settings, minStepTime,
+  sysid::InitialTrimAndFilter(&preparedData, &settings, minStepTime,
                               maxStepTime);
   // Store filtered data
   auto& slowForwardLeft = preparedData["left-slow-forward"];
@@ -602,6 +602,7 @@ AnalysisManager::AnalysisManager(std::string_view path, Settings& settings,
 
   // Reset settings for Dynamic Test Limits
   m_settings.stepTestDuration = units::second_t{0.0};
+  m_settings.motionThreshold = 100000;
   m_minDuration = units::second_t{100000};
 }
 

--- a/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
 #include <vector>
@@ -602,7 +603,7 @@ AnalysisManager::AnalysisManager(std::string_view path, Settings& settings,
 
   // Reset settings for Dynamic Test Limits
   m_settings.stepTestDuration = units::second_t{0.0};
-  m_settings.motionThreshold = 100000;
+  m_settings.motionThreshold = std::numeric_limits<double>::infinity();
   m_minDuration = units::second_t{100000};
 }
 

--- a/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/sysid-application/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "sysid/analysis/FilteringUtils.h"
 
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <vector>
@@ -273,7 +274,7 @@ void sysid::InitialTrimAndFilter(
   maxStepTime = GetMaxTime(preparedData);
 
   // Calculate Velocity Threshold if it hasn't been set yet
-  if (settings->motionThreshold >= 100000) {
+  if (settings->motionThreshold == std::numeric_limits<double>::infinity()) {
     for (auto& it : preparedData) {
       auto key = it.first();
       auto& dataset = it.getValue();

--- a/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -59,11 +59,6 @@ class AnalysisManager {
     double motionThreshold = 0.2;
 
     /**
-     * The window size for computing acceleration.
-     */
-    int accelerationWindow = 9;
-
-    /**
      * The window size for the median filter.
      */
     int medianWindow = 1;

--- a/sysid-application/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -20,6 +20,8 @@
 
 namespace sysid {
 
+constexpr int kNoiseMeanWindow = 9;
+
 /**
  * Calculates the expected acceleration noise to be used as the floor of the
  * Voltage Trim. This is done by taking the standard deviation from the moving
@@ -27,9 +29,13 @@ namespace sysid {
  *
  * @param data the prepared data vector containing acceleration data
  * @param window the size of the window for the moving average
+ * @param accessorFunction a function that accesses the desired data from the
+ *                         PreparedData struct.
  * @return The expected acceleration noise
  */
-double GetAccelNoiseFloor(const std::vector<PreparedData>& data, int window);
+double GetNoiseFloor(
+    const std::vector<PreparedData>& data, int window,
+    std::function<double(const PreparedData&)> accessorFunction);
 
 /**
  * Reduces noise in velocity data by applying a median filter.
@@ -128,7 +134,7 @@ frc::LinearFilter<double> CentralFiniteDifference(units::second_t period) {
  *             cosine data)
  */
 void InitialTrimAndFilter(wpi::StringMap<std::vector<PreparedData>>* data,
-                          AnalysisManager::Settings& settings,
+                          AnalysisManager::Settings* settings,
                           units::second_t& minStepTime,
                           units::second_t& maxStepTime,
                           std::string_view unit = "");

--- a/sysid-application/src/test/native/cpp/analysis/FilterTest.cpp
+++ b/sysid-application/src/test/native/cpp/analysis/FilterTest.cpp
@@ -30,14 +30,15 @@ TEST(FilterTest, MedianFilter) {
   EXPECT_EQ(expectedData, testData);
 }
 
-TEST(FilterTest, AccelNoiseFloor) {
+TEST(FilterTest, NoiseFloor) {
   std::vector<sysid::PreparedData> testData = {
       {0_s, 1, 2, 3, 5_ms, 0, 0},    {1_s, 1, 2, 3, 5_ms, 1, 0},
       {2_s, 1, 2, 3, 5_ms, 2, 0},    {3_s, 1, 2, 3, 5_ms, 5, 0},
       {4_s, 1, 2, 3, 5_ms, 0.35, 0}, {5_s, 1, 2, 3, 5_ms, 0.15, 0},
       {6_s, 1, 2, 3, 5_ms, 0, 0},    {7_s, 1, 2, 3, 5_ms, 0.02, 0},
       {8_s, 1, 2, 3, 5_ms, 0.01, 0}, {9_s, 1, 2, 3, 5_ms, 0, 0}};
-  double noiseFloor = GetAccelNoiseFloor(testData, 2);
+  double noiseFloor =
+      GetNoiseFloor(testData, 2, [](auto&& pt) { return pt.acceleration; });
   EXPECT_NEAR(0.953, noiseFloor, 0.001);
 }
 


### PR DESCRIPTION
This should automatically calculate the velocity motion threshold for quasistatic tests through the noise floor from a moving standard deviation.

Fixes #327 