### PR TITLE
Upgrade PWF to 2022.01.17

### DIFF
--- a/vendordeps/playingwithfusion2022.json
+++ b/vendordeps/playingwithfusion2022.json
@@ -1,70 +1,70 @@
 {
-  "fileName": "playingwithfusion2022.json",
-  "name": "PlayingWithFusion",
-  "version": "2022.01.03",
-  "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
-  "jsonUrl": "https://www.playingwithfusion.com/frc/playingwithfusion2022.json",
-  "mavenUrls": [
-      "https://www.playingwithfusion.com/frc/maven/"
-  ],
-  "javaDependencies": [
-      {
-          "groupId": "com.playingwithfusion.frc",
-          "artifactId": "PlayingWithFusion-java",
-          "version": "2022.01.03"
-      }
-  ],
-  "jniDependencies": [
-      {
-          "groupId": "com.playingwithfusion.frc",
-          "artifactId": "PlayingWithFusion-driver",
-          "version": "2022.01.03",
-          "isJar": false,
-          "skipInvalidPlatforms": true,
-          "validPlatforms": [
-              "linuxaarch64bionic",
-              "linuxathena",
-              "linuxraspbian",
-              "linuxx86-64",
-              "osxx86-64",
-              "windowsx86-64"
-          ]
-      }
-  ],
-  "cppDependencies": [
-      {
-          "groupId": "com.playingwithfusion.frc",
-          "artifactId": "PlayingWithFusion-cpp",
-          "version": "2022.01.03",
-          "headerClassifier": "headers",
-          "sharedLibrary": false,
-          "libName": "PlayingWithFusion",
-          "skipInvalidPlatforms": true,
-          "binaryPlatforms": [
-              "linuxaarch64bionic",
-              "linuxathena",
-              "linuxraspbian",
-              "linuxx86-64",
-              "osxx86-64",
-              "windowsx86-64"
-          ]
-      },
-      {
-          "groupId": "com.playingwithfusion.frc",
-          "artifactId": "PlayingWithFusion-driver",
-          "version": "2022.01.03",
-          "headerClassifier": "headers",
-          "sharedLibrary": true,
-          "libName": "PlayingWithFusionDriver",
-          "skipInvalidPlatforms": true,
-          "binaryPlatforms": [
-              "linuxaarch64bionic",
-              "linuxathena",
-              "linuxraspbian",
-              "linuxx86-64",
-              "osxx86-64",
-              "windowsx86-64"
-          ]
-      }
-  ]
+    "fileName": "playingwithfusion2022.json",
+    "name": "PlayingWithFusion",
+    "version": "2022.01.17",
+    "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
+    "jsonUrl": "https://www.playingwithfusion.com/frc/playingwithfusion2022.json",
+    "mavenUrls": [
+        "https://www.playingwithfusion.com/frc/maven/"
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-java",
+            "version": "2022.01.17"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2022.01.17",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxaarch64bionic",
+                "linuxathena",
+                "linuxraspbian",
+                "linuxx86-64",
+                "osxx86-64",
+                "windowsx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-cpp",
+            "version": "2022.01.17",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "libName": "PlayingWithFusion",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxaarch64bionic",
+                "linuxathena",
+                "linuxraspbian",
+                "linuxx86-64",
+                "osxx86-64",
+                "windowsx86-64"
+            ]
+        },
+        {
+            "groupId": "com.playingwithfusion.frc",
+            "artifactId": "PlayingWithFusion-driver",
+            "version": "2022.01.17",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "libName": "PlayingWithFusionDriver",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxaarch64bionic",
+                "linuxathena",
+                "linuxraspbian",
+                "linuxx86-64",
+                "osxx86-64",
+                "windowsx86-64"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This fixes a crash when running the analysis integration tests locally
with the simulation GUI open.