### PR TITLE
Add theoretical mode

### DIFF
--- a/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -154,6 +154,15 @@ class AnalysisManager {
   }
 
   /**
+   * Constructs an instance of the analysis manager for theoretical analysis,
+   * containing settings and gains but no data.
+   *
+   * @param settings The settings for this instance of the analysis manager.
+   * @param logger The logger instance to use for log data.
+   */
+  AnalysisManager(Settings& settings, wpi::Logger& logger);
+
+  /**
    * Constructs an instance of the analysis manager with the given path (to the
    * JSON) and analysis manager settings.
    *
@@ -179,12 +188,12 @@ class AnalysisManager {
   FeedforwardGains CalculateFeedforward();
 
   /**
-   * Calculates the gains with the latest data (from the pointers in the
-   * settings struct that this instance was constructed with).
+   * Calculates feedback gains from the given feedforward gains.
    *
-   * @return The latest feedback gains.
+   * @param ff The feedforward gains.
+   * @return The calculated feedback gains.
    */
-  FeedbackGains CalculateFeedback();
+  FeedbackGains CalculateFeedback(std::vector<double> ff);
 
   /**
    * Overrides the units in the JSON with the user-provided ones.
@@ -301,10 +310,6 @@ class AnalysisManager {
 
   units::second_t m_minDuration;
   units::second_t m_maxDuration;
-
-  // Stores feedforward gains
-  FeedforwardGains m_ffGains;
-  FeedbackGains m_fbGains;
 
   // Stores an optional track width if we are doing the drivetrain angular test.
   std::optional<double> m_trackWidth;

--- a/sysid-application/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid-application/src/main/native/include/sysid/view/Analyzer.h
@@ -46,10 +46,6 @@ class Analyzer : public glass::View {
   enum class AnalyzerState {
     kWaitingForJSON,
     kNominalDisplay,
-    kDataPrep,
-    kFeedforwardGainCalc,
-    kFeedbackGainCalc,
-    kGraphPrep,
     kMotionThresholdError,
     kTestDurationError,
     kGeneralDataError,
@@ -121,6 +117,11 @@ class Analyzer : public glass::View {
   void DisplayFileSelector();
 
   /**
+   * Resets the current analysis data.
+   */
+  void ResetData();
+
+  /**
    * Sets up the reset button and Unit override buttons.
    *
    * @return True if the tool had been reset.
@@ -128,9 +129,19 @@ class Analyzer : public glass::View {
   bool DisplayResetAndUnitOverride();
 
   /**
+   * Prepares the data for analysis.
+   */
+  void PrepareData();
+
+  /**
    * Sets up the graphs to display Raw Data.
    */
   void PrepareRawGraphs();
+
+  /**
+   * Sets up the graphs to display filtered/processed data.
+   */
+  void PrepareGraphs();
 
   /**
    * True if the stored state is associated with an error.
@@ -143,12 +154,17 @@ class Analyzer : public glass::View {
   bool IsDataErrorState();
 
   /**
-   * Handles the logic for displaying feedforward gains
+   * Displays inputs to allow the collecting of theoretical feedforward gains.
+   */
+  void CollectFeedforwardGains(float beginX, float beginY);
+
+  /**
+   * Displays calculated feedforward gains.
    */
   void DisplayFeedforwardGains(float beginX, float beginY);
 
   /**
-   * Handles the logic for displaying feedback gains
+   * Displays calculated feedback gains.
    */
   void DisplayFeedbackGains();
 
@@ -159,9 +175,19 @@ class Analyzer : public glass::View {
   void ConfigParamsOnFileSelect();
 
   /**
+   * Updates feedforward gains from the analysis manager.
+   */
+  void UpdateFeedforwardGains();
+
+  /**
+   * Updates feedback gains from the analysis manager.
+   */
+  void UpdateFeedbackGains();
+
+  /**
    * Handles logic of displaying a gain on ImGui
    */
-  void DisplayGain(const char* text, double* data);
+  bool DisplayGain(const char* text, double* data, bool readOnly);
 
   /**
    * Handles errors when they pop up.
@@ -198,13 +224,10 @@ class Analyzer : public glass::View {
   std::optional<double> m_trackWidth;
 
   // Units
-  double m_factor;
-  std::string m_unit;
   int m_selectedOverrideUnit = 0;
 
   // Data analysis
   std::unique_ptr<AnalysisManager> m_manager;
-  AnalysisType m_type;
   int m_dataset = 0;
   int m_window = 8;
   double m_threshold = 0.2;


### PR DESCRIPTION
Replaces the "waiting for data json" state with a theoretical analysis mode that allows you to plug in your own calculated feedforward gains for use with LQR.  Also refactors the state machine to get rid of states that do nothing but call code and transition to other states (these are now just subroutines).