### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/scripts/time_plots.py
+++ b/scripts/time_plots.py
@@ -54,8 +54,9 @@ if filename.endswith(".json"):
     prepared_data = pd.DataFrame(columns=columns)
     for test in (test for test in raw_data.keys() if "-" in test):
         formatted_entry = [[pt[0]] + [test] + pt[1:] for pt in raw_data[test]]
-        prepared_data = prepared_data.append(
-            pd.DataFrame(formatted_entry, columns=columns))
+        prepared_data = pd.concat(
+            [prepared_data,
+             pd.DataFrame(formatted_entry, columns=columns)])
 
     units_per_rot = raw_data["unitsPerRotation"]
 


### PR DESCRIPTION
```
/home/tav/frc/wpilib/sysid/scripts/time_plots.py:57: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  prepared_data = prepared_data.append(
```