### PR TITLE
Make Spark Max encoder port the default instead of data port

### DIFF
--- a/sysid-application/src/main/native/include/sysid/view/Generator.h
+++ b/sysid-application/src/main/native/include/sysid/view/Generator.h
@@ -75,8 +75,8 @@ static constexpr std::array<const char*, 1> kBuiltInEncoders{
     sysid::encoder::kBuiltInSetting.displayName};
 
 static constexpr std::array<const char*, 2> kSparkMaxEncoders{
-    sysid::encoder::kSMaxDataPort.displayName,
-    sysid::encoder::kSMaxEncoderPort.displayName};
+    sysid::encoder::kSMaxEncoderPort.displayName,
+    sysid::encoder::kSMaxDataPort.displayName};
 
 static constexpr auto kGyroNames = DisplayNameStorage(sysid::gyro::kGyros);
 static constexpr const char* kNavXCtors[] = {"SerialPort (USB)", "I2C (MXP)",


### PR DESCRIPTION
From what I have seen the encoder port is used much more than the data port. I don't know if there was a specific reason that data port was the default before.