### PR TITLE
Only graph when data is present

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid-application/src/main/native/cpp/view/Analyzer.cpp
@@ -355,23 +355,27 @@ void Analyzer::PrepareData() {
 }
 
 void Analyzer::PrepareRawGraphs() {
-  AbortDataPrep();
-  m_dataThread = std::thread([&] {
-    m_plot.SetRawData(m_manager->GetOriginalData(), m_manager->GetUnit(),
-                      m_abortDataPrep);
-  });
+  if (m_manager->HasData()) {
+    AbortDataPrep();
+    m_dataThread = std::thread([&] {
+      m_plot.SetRawData(m_manager->GetOriginalData(), m_manager->GetUnit(),
+                        m_abortDataPrep);
+    });
+  }
 }
 
 void Analyzer::PrepareGraphs() {
-  WPI_INFO(m_logger, "{}", "Graph state");
-  AbortDataPrep();
-  m_dataThread = std::thread([&] {
-    m_plot.SetData(m_manager->GetRawData(), m_manager->GetFilteredData(),
-                   m_manager->GetUnit(), m_ff, m_manager->GetStartTimes(),
-                   m_manager->GetAnalysisType(), m_abortDataPrep);
-  });
-  UpdateFeedbackGains();
-  m_state = AnalyzerState::kNominalDisplay;
+  if (m_manager->HasData()) {
+    WPI_INFO(m_logger, "{}", "Graph state");
+    AbortDataPrep();
+    m_dataThread = std::thread([&] {
+      m_plot.SetData(m_manager->GetRawData(), m_manager->GetFilteredData(),
+                     m_manager->GetUnit(), m_ff, m_manager->GetStartTimes(),
+                     m_manager->GetAnalysisType(), m_abortDataPrep);
+    });
+    UpdateFeedbackGains();
+    m_state = AnalyzerState::kNominalDisplay;
+  }
 }
 
 void Analyzer::HandleError(std::string_view msg) {

--- a/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -307,7 +307,15 @@ class AnalysisManager {
    *
    * @return The start times for each test
    */
-  const std::array<units::second_t, 4> GetStartTimes() { return m_startTimes; }
+  const std::array<units::second_t, 4>& GetStartTimes() const {
+    return m_startTimes;
+  }
+
+  bool HasData() const {
+    return !m_originalDataset[static_cast<int>(
+                                  Settings::DrivetrainDataset::kCombined)]
+                .empty();
+  }
 
  private:
   wpi::Logger& m_logger;


### PR DESCRIPTION
Fixes #393 

Previously changing the graphing settings before any data was present would lead to it crashing.