### PR TITLE
Change some time constants to milliseconds

### DIFF
--- a/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -282,9 +282,9 @@ class AnalysisManager {
    * Returns the estimated time delay of the measured position, including
    * CAN delays.
    *
-   * @return Position delay
+   * @return Position delay in milliseconds
    */
-  units::second_t GetPositionDelay() const {
+  units::millisecond_t GetPositionDelay() const {
     return std::accumulate(m_positionDelays.begin(), m_positionDelays.end(),
                            0_s) /
            m_positionDelays.size();
@@ -294,9 +294,9 @@ class AnalysisManager {
    * Returns the estimated time delay of the measured velocity, including
    * CAN delays.
    *
-   * @return Velocity delay
+   * @return Velocity delay in milliseconds
    */
-  units::second_t GetVelocityDelay() const {
+  units::millisecond_t GetVelocityDelay() const {
     return std::accumulate(m_velocityDelays.begin(), m_velocityDelays.end(),
                            0_s) /
            m_positionDelays.size();

--- a/sysid-application/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
+++ b/sysid-application/src/main/native/include/sysid/analysis/FeedbackControllerPreset.h
@@ -29,7 +29,7 @@ struct FeedbackControllerPreset {
   /**
    * The period at which the controller runs.
    */
-  units::second_t period;
+  units::millisecond_t period;
 
   /**
    * Whether the controller gains are time-normalized.
@@ -39,7 +39,7 @@ struct FeedbackControllerPreset {
   /**
    * The measurement delay in the encoder measurements.
    */
-  units::second_t measurementDelay;
+  units::millisecond_t measurementDelay;
 
   /**
    * Checks equality between two feedback controller presets.

--- a/sysid-application/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid-application/src/main/native/include/sysid/view/Analyzer.h
@@ -218,7 +218,7 @@ class Analyzer : public glass::View {
   double m_accelRMSE;
   double m_Kp;
   double m_Kd;
-  double m_timescale;
+  units::millisecond_t m_timescale;
 
   // Track width
   std::optional<double> m_trackWidth;


### PR DESCRIPTION
Also adds a guard for divide-by-zero when when using kv/ka to determine a time constant.