### PR TITLE
Fix initialization errors in generation integration tests

### DIFF
--- a/sysid-library/src/main/cpp/generation/SysIdSetup.cpp
+++ b/sysid-library/src/main/cpp/generation/SysIdSetup.cpp
@@ -83,12 +83,10 @@ void AddMotorController(
       fmt::print("Setup SPARK MAX (Brushless)\n");
       controllers->emplace_back(std::make_unique<rev::CANSparkMax>(
           port, rev::CANSparkMax::MotorType::kBrushless));
-      controllers->emplace_back(std::make_unique<frc::Spark>(port));
     } else {
       fmt::print("Setup SPARK MAX (Brushed)\n");
       controllers->emplace_back(std::make_unique<rev::CANSparkMax>(
           port, rev::CANSparkMax::MotorType::kBrushed));
-      controllers->emplace_back(std::make_unique<frc::Spark>(port));
     }
 
     auto* sparkMax = static_cast<rev::CANSparkMax*>(controllers->back().get());
@@ -109,7 +107,6 @@ void AddMotorController(
     controllers->emplace_back(std::make_unique<frc::Spark>(port));
     auto* spark = static_cast<frc::Spark*>(controllers->back().get());
     spark->SetInverted(inverted);
-    controllers->emplace_back(std::make_unique<frc::Spark>(port));
   }
 }
 


### PR DESCRIPTION
Generation integration tests are still failing due to scheduling problems, but this at least removes the existing DIO/PWM errors caused by overlapping HAL allocations.