### PR TITLE
Analyzer: initialize m_graphScroll

### DIFF
--- a/sysid-application/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid-application/src/main/native/include/sysid/view/Analyzer.h
@@ -253,7 +253,7 @@ class Analyzer : public glass::View {
 
   // Stores graph scroll bar position and states for keeping track of scroll
   // positions after loading graphs
-  float m_graphScroll;
+  float m_graphScroll = 0;
 
   std::atomic<bool> m_abortDataPrep{false};
   std::thread m_dataThread;


### PR DESCRIPTION
This is read at Analyzer.cpp:422, and sufficiently large values could cause the GUI to lock up due to creating unreasonably large window positions.