### PR TITLE
Make Spark Max built-in encoder sampling and measurement period configurable

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Generator.cpp
+++ b/sysid-application/src/main/native/cpp/view/Generator.cpp
@@ -4,6 +4,7 @@
 
 #include "sysid/view/Generator.h"
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -199,7 +200,16 @@ void Generator::UpdateFromConfig() {
 
   const auto& gyroNames = kGyroNames.names;
   m_gyroIdx = GetNewIdx(gyroNames, m_settings.gyro.displayName);
-  m_periodIdx = GetNewIdx(kCTREPeriods, std::to_string(m_settings.period));
+  if (mainMotorController == sysid::motorcontroller::kSPARKMAXBrushless) {
+    m_numSamplesIdx =
+        GetNewIdx(kCTREPeriods, std::to_string(m_settings.period));
+    m_periodIdx = GetNewIdx(kCTREPeriods, std::to_string(m_settings.period));
+  } else if (mainMotorController ==
+             sysid::motorcontroller::kSPARKMAXBrushless) {
+    m_numSamplesIdx =
+        GetNewIdx(kCTREPeriods, std::to_string(m_settings.period));
+    m_periodIdx = GetNewIdx(kCTREPeriods, std::to_string(m_settings.period));
+  }
 
   // Read in Gyro Constructors
   if (m_settings.gyro == sysid::gyro::kPigeon) {
@@ -459,29 +469,53 @@ void Generator::Display() {
     }
   }
 
-  // Venom or NEO built-in encoders can't change sampling or measurement period.
+  // Venom built-in encoder, TalonFX Pro built-in encoder, and CANcoder Pro
+  // can't change number of samples or measurement window.
   if (!((mainMotorController == sysid::motorcontroller::kVenom &&
          m_settings.encoderType == sysid::encoder::kBuiltInSetting) ||
-        (mainMotorController == sysid::motorcontroller::kSPARKMAXBrushless &&
-         m_settings.encoderType == sysid::encoder::kSMaxEncoderPort) ||
         (mainMotorController == sysid::motorcontroller::kTalonFXPro &&
          m_settings.encoderType == sysid::encoder::kBuiltInSetting) ||
         m_settings.encoderType == sysid::encoder::kCANcoderPro)) {
     // Samples Per Average Setting
-    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 2);
-    ImGui::InputInt("Samples Per Average", &m_settings.numSamples, 0, 0);
+    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
+    if (m_settings.encoderType == sysid::encoder::kBuiltInSetting) {
+      if (mainMotorController == sysid::motorcontroller::kSPARKMAXBrushless) {
+        if (ImGui::Combo("Samples Per Average", &m_numSamplesIdx,
+                         kREVBuiltInNumSamples,
+                         IM_ARRAYSIZE(kREVBuiltInNumSamples))) {
+          m_settings.numSamples =
+              std::stoi(kREVBuiltInNumSamples[m_numSamplesIdx]);
+        }
+      } else if (mainMotorController == sysid::motorcontroller::kTalonFX) {
+        if (ImGui::Combo("Samples Per Average", &m_numSamplesIdx,
+                         kCTREBuiltInNumSamples,
+                         IM_ARRAYSIZE(kCTREBuiltInNumSamples))) {
+          m_settings.numSamples =
+              std::stoi(kCTREBuiltInNumSamples[m_numSamplesIdx]);
+        }
+      }
+    } else {
+      ImGui::InputInt("Samples Per Average", &m_settings.numSamples, 0, 0);
+    }
     CreateTooltip(
         "This helps reduce encoder noise by averaging collected samples "
         "together. A value from 5-10 is reccomended for encoders with high "
         "CPRs.");
 
     // Add Velocity Measurement Period
-    if (m_settings.encoderType != sysid::encoder::kRoboRIO &&
-        m_settings.encoderType != sysid::encoder::kCANcoderPro) {
-      ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
-      ImGui::Combo("Time Measurement Window", &m_periodIdx, kCTREPeriods,
-                   IM_ARRAYSIZE(kCTREPeriods));
-      m_settings.period = std::stoi(std::string{kCTREPeriods[m_periodIdx]});
+    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
+    if (m_settings.encoderType == sysid::encoder::kBuiltInSetting) {
+      if (mainMotorController == sysid::motorcontroller::kSPARKMAXBrushless) {
+        if (ImGui::Combo("Time Measurement Window", &m_periodIdx, kREVPeriods,
+                         IM_ARRAYSIZE(kREVPeriods))) {
+          m_settings.numSamples = std::stoi(kREVPeriods[m_periodIdx]);
+        }
+      } else if (mainMotorController == sysid::motorcontroller::kTalonFX) {
+        if (ImGui::Combo("Time Measurement Window", &m_periodIdx, kCTREPeriods,
+                         IM_ARRAYSIZE(kCTREPeriods))) {
+          m_settings.numSamples = std::stoi(kCTREPeriods[m_periodIdx]);
+        }
+      }
     }
   }
 

--- a/sysid-application/src/main/native/include/sysid/view/Generator.h
+++ b/sysid-application/src/main/native/include/sysid/view/Generator.h
@@ -93,7 +93,21 @@ static constexpr const char* kADIS16470Ctors[] = {
     "SPI (Onboard CS0)", "SPI (Onboard CS1)", "SPI (Onboard CS2)",
     "SPI (Onboard CS3)", "SPI (MXP)"};
 
-static constexpr const char* kCTREPeriods[] = {"1",  "2",  "5",  "10",
+// https://codedocs.revrobotics.com/cpp/classrev_1_1_spark_max_relative_encoder.html#ad2220467e1725840dbe77db4278a8d80
+static constexpr const char* kREVBuiltInNumSamples[] = {"1", "2", "4", "8"};
+
+// https://codedocs.revrobotics.com/cpp/classrev_1_1_spark_max_relative_encoder.html#a8922f3c305ef6e57d7f639a17496c45d
+static constexpr const char* kREVPeriods[] = {
+    "8",  "9",  "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+    "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
+    "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43",
+    "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55",
+    "56", "57", "58", "59", "60", "61", "62", "63", "64"};
+
+// https://docs.ctre-phoenix.com/en/stable/ch14_MCSensor.html#changing-velocity-measurement-parameters
+static constexpr const char* kCTREBuiltInNumSamples[] = {"1",  "2",  "4", "8",
+                                                         "16", "32", "64"};
+static constexpr const char* kCTREPeriods[] = {"1",  "5",  "10", "20",
                                                "25", "50", "100"};
 
 /**
@@ -168,6 +182,13 @@ class Generator : public glass::View {
     ImGui::Combo("Encoder", &m_encoderIdx, encoders.data(), encoders.size());
     m_settings.encoderType =
         sysid::encoder::FromEncoderName(encoders[m_encoderIdx]);
+    if (m_settings.motorControllers[0] ==
+            sysid::motorcontroller::kSPARKMAXBrushless &&
+        m_settings.encoderType == sysid::encoder::kSMaxEncoderPort) {
+      // Spark Max built-in encoder number of samples must be within 8 to 64
+      // inclusive
+      m_settings.numSamples = 8;
+    }
   }
 
   // Configuration manager along with its settings -- used to generate the JSON
@@ -184,7 +205,8 @@ class Generator : public glass::View {
   int m_encoderIdx = 0;
   int m_gyroIdx = 0;
   int m_unitsIdx = 0;
-  int m_periodIdx = 6;
+  int m_numSamplesIdx = 0;
+  int m_periodIdx = 0;
 
   HardwareType m_prevMainMotorController = sysid::motorcontroller::kPWM;
 


### PR DESCRIPTION
The number of samples must be between 8 and 64 inclusive.