### PR TITLE
Fix inversion checkbox showing up on built in Spark MAX and TalonFX encoder settings

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Generator.cpp
+++ b/sysid-application/src/main/native/cpp/view/Generator.cpp
@@ -441,7 +441,7 @@ void Generator::Display() {
                  sysid::motorcontroller::kSPARKMAXBrushless) {
     GetEncoder(ArrayConcat(kSparkMaxEncoders, kGeneralEncoders));
     if (m_encoderIdx <= 1) {
-      if (!(m_encoderIdx == 1 &&
+      if (!(m_encoderIdx == 0 &&
             mainMotorController ==
                 sysid::motorcontroller::kSPARKMAXBrushless)) {
         // You're not allowed to invert the NEO Built-in encoder

--- a/sysid-application/src/main/native/cpp/view/Generator.cpp
+++ b/sysid-application/src/main/native/cpp/view/Generator.cpp
@@ -419,8 +419,8 @@ void Generator::Display() {
     if (mainMotorController == sysid::motorcontroller::kTalonFX ||
         mainMotorController == sysid::motorcontroller::kTalonFXPro) {
       GetEncoder(ArrayConcat(kBuiltInEncoders, kGeneralEncoders));
-      if (m_encoderIdx < 1) {
-        RegularEncoderSetup(drive);
+      if (m_encoderIdx == 0) {
+        // Built in encoder on TalonFX can't be inverted.
       } else if (m_encoderIdx == 1 || m_encoderIdx == 2) {
         CANCoderSetup(drive, m_encoderIdx == 2);
       } else {


### PR DESCRIPTION
Fixes #490 
Fixes #489 

Spark MAX Bug introduced in #385 due to option indices changing.
