### PR TITLE
Give measurement period a valid default of 1

### DIFF
--- a/sysid-application/src/main/native/cpp/view/Generator.cpp
+++ b/sysid-application/src/main/native/cpp/view/Generator.cpp
@@ -509,14 +509,14 @@ void Generator::Display() {
         m_settings.encoderType == sysid::encoder::kSMaxEncoderPort) {
       if (ImGui::Combo("Time Measurement Window", &m_periodIdx, kREVPeriods,
                        IM_ARRAYSIZE(kREVPeriods)) ||
-          m_settings.period == 0) {
+          m_settings.period == 1) {
         m_settings.period = std::stoi(kREVPeriods[m_periodIdx]);
       }
     } else if (mainMotorController == sysid::motorcontroller::kTalonFX &&
                m_settings.encoderType == sysid::encoder::kBuiltInSetting) {
       if (ImGui::Combo("Time Measurement Window", &m_periodIdx, kCTREPeriods,
                        IM_ARRAYSIZE(kCTREPeriods)) ||
-          m_settings.period == 0) {
+          m_settings.period == 1) {
         m_settings.period = std::stoi(kCTREPeriods[m_periodIdx]);
       }
     }

--- a/sysid-application/src/main/native/include/sysid/generation/ConfigManager.h
+++ b/sysid-application/src/main/native/include/sysid/generation/ConfigManager.h
@@ -152,7 +152,7 @@ struct ConfigSettings {
   /**
    * The period of time in which the velocity is calculated.
    */
-  int period = 0;
+  int period = 1;
 
   /**
    * If the configuration is for a drivetrain.


### PR DESCRIPTION
A default of 0 works for neither REV (brushed) nor CTRE.