### PR TITLE
Strip executable in release build

### DIFF
--- a/sysid-application/build.gradle
+++ b/sysid-application/build.gradle
@@ -168,8 +168,14 @@ model {
             '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' <<
             'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
         it.linker.args << '-framework' << 'Kerberos'
+        if (it.buildType.getName() == "release") {
+          it.linker.args << '-s'
+        }
       } else {
         it.linker.args << '-lX11'
+        if (it.buildType.getName() == "release") {
+          it.linker.args << '-s'
+        }
       }
 
       // Define NDEBUG in Release Mode (needed for proper wpi::Logger functionality).

--- a/sysid-application/config/publish.gradle
+++ b/sysid-application/config/publish.gradle
@@ -37,7 +37,8 @@ model {
           from("../LICENSE.md") { into '/' }
           from("../ThirdPartyNotices.txt") { into '/' }
           from(exe)
-          if (binary.targetPlatform.operatingSystem.isWindows()) {
+          if (binary.targetPlatform.operatingSystem.isWindows() &&
+              !binary.name.contains("release")) {
               def exePath = binary.executable.file.absolutePath
               exePath = exePath.substring(0, exePath.length() - 4)
               def pdbPath = new File(exePath + '.pdb')


### PR DESCRIPTION
This will drastically reduce release artifact sizes (100-200 MB smaller) to make more room in the WPILib installer.